### PR TITLE
[APB-1190][JR] For diagnosing DES call in QA only - not intended to b…

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/GuiceModule.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/GuiceModule.scala
@@ -40,6 +40,7 @@ class GuiceModule(val environment: Environment, val configuration: Configuration
     bind(classOf[AuditConnector]).toInstance(FrontendAuditConnector)
     bindBaseUrl("sso")
     bindBaseUrl("des")
+    bindBaseUrl("agent-subscription")
     bindServiceProperty("des.authorization-token")
     bindServiceProperty("des.environment")
   }

--- a/app/uk/gov/hmrc/agentservicesaccount/connectors/AgentSubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/connectors/AgentSubscriptionConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentservicesaccount.connectors
+
+import java.net.URL
+import javax.inject.{Inject, Named, Singleton}
+
+import play.api.libs.json.JsValue
+import play.utils.UriEncoding
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost}
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
+
+import scala.concurrent.Future
+
+@Singleton
+class AgentSubscriptionConnector @Inject()(@Named("agent-subscription-baseUrl") baseUrl: URL, http: HttpGet with HttpPost) {
+
+  def getAgencyName(arn: Arn)(implicit hc: HeaderCarrier): Future[Option[String]] = {
+    val encodedArn = UriEncoding.encodePathSegment(arn.value, "UTF-8")
+    val url = new URL(baseUrl, s"/agent-subscription/test-only/agency-name/$encodedArn").toString
+
+    http.GET[JsValue](url).map { json =>
+      (json \ "name").asOpt[String]
+    }
+  }
+}

--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesController.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.agentservicesaccount.AppConfig
 import uk.gov.hmrc.agentservicesaccount.auth.AuthActions
 import uk.gov.hmrc.agentservicesaccount.config.ExternalUrls
-import uk.gov.hmrc.agentservicesaccount.connectors.DesConnector
+import uk.gov.hmrc.agentservicesaccount.connectors.{AgentSubscriptionConnector, DesConnector}
 import uk.gov.hmrc.agentservicesaccount.views.html.pages._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
@@ -32,7 +32,7 @@ class AgentServicesController @Inject()(
                                          val messagesApi: MessagesApi,
                                          authActions: AuthActions,
                                          continueUrlActions: ContinueUrlActions,
-                                         desConnector: DesConnector)
+                                         subsConnector: AgentSubscriptionConnector)
                                        (implicit val externalUrls: ExternalUrls, appConfig: AppConfig) extends FrontendController with I18nSupport {
 
   import authActions._
@@ -41,7 +41,7 @@ class AgentServicesController @Inject()(
   val root: Action[AnyContent] = (AuthorisedWithAgentAsync andThen WithMaybeContinueUrl).async {
     implicit request =>
       for {
-        maybeAgencyName <- desConnector.getAgencyName(request.arn)
+        maybeAgencyName <- subsConnector.getAgencyName(request.arn)
       } yield Ok(agent_services_account(request.arn, maybeAgencyName, request.continueUrlOpt))
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,6 +94,11 @@ microservice {
       authorization-token=secret
       environment=test
     }
+
+    agent-subscription {
+      host = localhost
+      port = 9436
+    }
   }
 }
 


### PR DESCRIPTION
This is for diagnosing a DES call in QA only - it's not intended to be released beyond QA and is intended to be reverted after a test. Related to https://github.com/hmrc/agent-subscription/pull/54

The agent-services-account-frontend is failing to call a DES API in the QA environment. We have a theory that this is because DES can only be called from the protected zone, not the public zone.

To test that, instead of calling the DES API from the agent-services-account-frontend directly, that service will call a test-only endpoint in the agent-subscription backend which then calls the DES API. If that works in QA it confirms that we need a new agent-services-account backend in order to make the DES API call because it can't be done in the frontend. If it doesn't work, then there's some other problem.