### PR TITLE
APB-5435 [CS] complete migration & fix welsh language toggle focus

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,95 +11,20 @@ hr.hr-thick {
   background: #0b0c0c;
 }
 
-.service-info {
-  display: block;
-  position: relative;
-  z-index: 997;
-  overflow: hidden;
-  padding-bottom: 0.5em;
-}
-
-.account-menu__link:visited {
-  color: #4A4A4A;
-}
-
-.centered-content {
-  font-family: "nta",Arial,sans-serif;
-  font-weight: 400;
-  text-transform: none;
-}
-
-.account-menu__link--home {
-  float: left;
-  padding: 12px 18px 8px 0;
-}
-
-.account-menu__link {
-  border-bottom: 4px solid transparent;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  color: #4A4A4A;
-  display: block;
-  font-size: 16px;
-  font-weight: 300;
-  line-height: 1.25;
-  padding: 12px 16px 8px;
-  text-transform: none;
-  text-decoration: none;
-
-  &:visited {
-    color: #4A4A4A;
-  }
-
-  &:hover,
-  &:focus {
-    border-bottom-style: solid;
-    border-bottom-width: 4px;
-    color: #2B8CC4;
-  }
-
-  &:hover {
-    border-bottom-color: #DEE0E2;
-  }
-
-  &:focus {
-    background-color: transparent;
-    border-bottom-color: #2B8CC4;
-  }
-}
-
-.account-icon--home {
-  background-image: url(data:image/svg+xml;base64,PHN2ZyBkYXRhLW5hbWU9IkxheWVyIDEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaW5ZTWlkIj48dGl0bGU+aWNvbi1ob21lPC90aXRsZT48cGF0aCBkPSJNMTIgMkwxIDEyLjVoMy4xOXY5LjM4aDUuNDR2LTcuMTNoNC41djcuMTNoNS40NFYxMi41SDIzTDEyIDJ6Ii8+PC9zdmc+);
-  background-position: left -1px;
-  background-size: 19px;
-  padding-left: 22px;
-}
-
-.account-icon {
-  background-repeat: no-repeat;
-}
-
-.flex-container {
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  padding: 0 15px 0 0;
-}
-
-.account-menu {
-  background-color: #fff;
-  border-bottom: 1px solid #bfc1c3;
-  margin-bottom: 0;
-  position: relative;
-  -webkit-transition: all .3s ease-in-out;
-  transition: all .3s ease-in-out;
-}
-
+// overrides phase banner for ASA
 .govuk-phase-banner {
   border-bottom: none;
+}
+
+// overrides hmrc-header css language toggle focus styles
+.hmrc-language-select {
+  .govuk-list {
+    a {
+      &:focus {
+            color: govuk-colour("black") !important;
+            background-color: govuk-colour("yellow")
+      }
+    }
+  }
+  text-decoration: none;
 }

--- a/app/uk/gov/hmrc/agentservicesaccount/views/main.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/main.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukLayout
 @import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 @import uk.gov.hmrc.agentservicesaccount.controllers.routes
-@import uk.gov.hmrc.agentservicesaccount.views.html.components._
+@import uk.gov.hmrc.agentservicesaccount.views.html.components.{header, head}
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/asa_dashboard.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/asa_dashboard.scala.html
@@ -42,7 +42,7 @@
         <li class="govuk-!-margin-bottom-1"><a class="govuk-link" href="@appConfig.agentInvitationsCancelAuthUrl">@Messages("agent.services.account.section4.col2.link3")</a></li>
     </ul>
 
-    <hr class="hr-thick govuk-!-margin-bottom-6">
+    <hr class="govuk-section-break hr-thick govuk-!-margin-bottom-6">
 
     <h2 class="govuk-heading-m">@Messages("agent.services.account.tax-services")</h2>
 
@@ -162,7 +162,7 @@
             </div>
         </div>
         <div>
-            <hr class="hr-thick govuk-!-margin-bottom-6">
+            <hr class="govuk-section-break hr-thick govuk-!-margin-bottom-6">
             <h2 class="govuk-heading-m" style="margin: 0px 0 5px">@Messages("agent.services.account.help.h2")</h2>
             <p class="govuk-body govuk-!-width-two-thirds"><a class="govuk-link" href="/agent-services-account/help-and-guidance">@Messages("agent.services.account.help.link")</a>.</p>
         </div>

--- a/build.sbt
+++ b/build.sbt
@@ -63,8 +63,7 @@ lazy val wartRemoverSettings = {
 }
 
 lazy val compileDeps = Seq(
-  "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.9.0",
-  "uk.gov.hmrc" %% "govuk-template"             % "5.70.0-play-28",
+  "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.16.0",
   "uk.gov.hmrc" %% "play-partials"              % "8.2.0-play-28",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
   "uk.gov.hmrc" %% "agent-mtd-identifiers"      % "0.25.0-play-27",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,7 +34,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
 
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.agentservicesaccount.ErrorHandler"

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -126,53 +126,6 @@ global.error.500.title=Mae’n ddrwg gennym, rydym yn profi anawsterau technegol
 global.error.500.heading=Mae’n ddrwg gennym, rydym yn profi anawsterau technegol
 global.error.500.message=Rhowch gynnig arall arni mewn ychydig o funudau.
 
-
-accessibility.statement.title=Datganiad hygyrchedd ar gyfer cyfrif gwasanaethau asiant
-accessibility.statement.h1=Datganiad hygyrchedd ar gyfer cyfrif gwasanaethau asiant
-accessibility.statement.intro.p1=Mae’r datganiad hygyrchedd hwn yn esbonio pa mor hygyrch yw’r gwasanaeth hwn, beth i’w wneud os ydych yn cael anhawster wrth ei ddefnyddio, a sut i roi gwybod am broblemau hygyrchedd gyda’r gwasanaeth.
-accessibility.statement.intro.p2=Mae’r gwasanaeth hwn yn rhan o wefan ehangach GOV.UK. Mae <a href="https://www.gov.uk/help/accessibility">datganiad hygyrchedd</a> ar wahân ar gyfer prif wefan GOV.UK.
-accessibility.statement.intro.p3=Mae’r dudalen hon yn cynnwys gwybodaeth am y gwasanaeth cyfrif gwasanaethau asiant yn unig, sydd ar gael yn <a href="https://www.tax.service.gov.uk/agent-subscription/task-list">www.tax.service.gov.uk/agent-subscription/task-list</a>.
-
-accessibility.statement.using.heading=Defnyddio’r gwasanaeth hwn
-accessibility.statement.using.p1=Mae’r gwasanaeth hwn yn eich galluogi i reoli’ch cyfrif gwasanaethau asiant CThEM ar gyfer eich cwmni asiant treth.
-accessibility.statement.using.p2=Mae’r gwasanaeth hwn yn cael ei redeg gan Gyllid a Thollau EM (CThEM). Rydym am i gymaint o bobl â phosibl allu defnyddio’r gwasanaeth hwn. Mae hyn yn golygu y dylech allu gwneud y canlynol:
-accessibility.statement.using.l1=newid lliwiau, lefelau cyferbyniad a ffontiau
-accessibility.statement.using.l2=chwyddo’r sgrin hyd at 300% heb i’r testun ddisgyn oddi ar y sgrin
-accessibility.statement.using.l3=mynd o ddechrau’r gwasanaeth i’r diwedd gan ddefnyddio bysellfwrdd yn unig
-accessibility.statement.using.l4=mynd o ddechrau’r gwasanaeth i’r diwedd gan ddefnyddio meddalwedd adnabod lleferydd
-accessibility.statement.using.l5=gwrando ar y gwasanaeth gan ddefnyddio darllenydd sgrin (gan gynnwys y fersiynau diweddaraf o JAWS, NVDA a VoiceOver)
-accessibility.statement.using.p3=Rydym hefyd wedi sicrhau bod y testun a ddefnyddir yn y gwasanaeth mor syml â phosibl i’w ddeall.
-accessibility.statement.using.p4=Mae gan <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> gyngor ar wneud eich dyfais yn haws i’w defnyddio os oes gennych anabledd.
-
-accessibility.statement.accessible.heading=Pa mor hygyrch yw’r gwasanaeth hwn
-accessibility.statement.accessible.p1=Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/">safon AA Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1</a>.
-
-accessibility.statement.whattodo.heading=Beth i’w wneud os ydych yn cael anhawster wrth ddefnyddio’r gwasanaeth hwn
-accessibility.statement.whattodo.p1=Os ydych yn cael anhawster wrth ddefnyddio’r gwasanaeth hwn, defnyddiwch y cysylltiad ‘Help gyda’r dudalen hon’ ar y dudalen yn y gwasanaeth ar-lein.
-
-accessibility.statement.reporting.heading=Rhoi gwybod am broblemau hygyrchedd gyda’r gwasanaeth hwn
-accessibility.statement.reporting.p1=Rydym bob amser yn ceisio gwella hygyrchedd y gwasanaeth hwn. Os byddwch yn dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon, neu os ydych o’r farn nad ydym yn bodloni gofynion hygyrchedd, rhowch wybod am y <a href="{0}" target="_blank">broblem hygyrchedd (yn agor tab newydd)</a>.
-
-accessibility.statement.enforcement.heading=Beth i’w wneud os nad ydych yn hapus â sut rydym yn ateb eich cwyn
-accessibility.statement.enforcement.p1=Mae’r Comisiwn Cydraddoldeb a Hawliau Dynol (EHRC) yn gyfrifol am orfodi Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Chymwysiadau Symudol) (Rhif 2) 2018 (y ‘rheoliadau hygyrchedd’). Os nad ydych yn hapus â sut rydym yn ateb eich cwyn,  <a href="https://www.equalityadvisoryservice.com/">cysylltwch â’r Gwasanaeth Cynghori a Chymorth Cydraddoldeb</a> (EASS), neu’r <a href="https://www.equalityni.org/Home">Equality Commission for Northern Ireland</a> (ECNI) os ydych yn byw yng Ngogledd Iwerddon.
-
-accessibility.statement.contacting.heading=Cysylltu â ni dros y ffôn neu gael ymweliad personol gennym
-accessibility.statement.contacting.p1=Rydym yn cynnig gwasanaeth text relay os ydych yn fyddar, â nam ar eich clyw neu os oes gennych nam ar eich lleferydd.
-accessibility.statement.contacting.p2=Gallwn ddarparu dehonglydd Iaith Arwyddion Prydain (BSL), neu gallwch drefnu ymweliad gan ymgynghorydd CThEM i’ch helpu i gwblhau’r gwasanaeth.
-accessibility.statement.contacting.p3=Gwybodaeth am sut i <a href="https://www.gov.uk/dealing-hmrc-additional-needs">gysylltu â ni</a>.
-
-accessibility.statement.technical.heading=Gwybodaeth dechnegol am hygyrchedd y gwasanaeth hwn
-accessibility.statement.technical.p1=Mae CThEM wedi ymrwymo i wneud y gwasanaeth hwn yn hygyrch, yn unol â Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Chymwysiadau Symudol) (Rhif 2) 2018.
-accessibility.statement.technical.p2=Mae’r gwasanaeth hwn yn cydymffurfio’n rhannol â <a href="https://www.w3.org/TR/WCAG21/">safon AA Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1</a>.
-
-accessibility.statement.technical.p3=Rydym wedi cynnal adolygiad arbenigol mewnol o’r gwasanaeth ac wedi trwsio pob mater hysbys o ran hygyrchedd.
-accessibility.statement.technical.p4=Byddwn yn trefnu archwiliad allanol ffurfiol o’r gwasanaeth cyfan cyn gynted â phosibl, fel rhan o’n cynllun ar gyfer sicrhau bod y gwasanaeth yn cydymffurfio’n llawn.
-
-accessibility.statement.howtested.heading=Sut gwnaethom brofi’r gwasanaeth hwn
-accessibility.statement.howtested.p1="Cafodd y gwasanaeth ei brofi ddiwethaf ar 22 Awst 2019 a gwiriwyd ei fod yn cydymffurfio â safon AA Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1."
-accessibility.statement.howtested.p2="Profwyd y gwasanaeth llawn gan CThEM, ac roedd y gwaith o brofi’r gwasanaeth yn cynnwys defnyddwyr anabl."
-accessibility.statement.howtested.p3=Paratowyd y dudalen hon ar 23 Medi 2019. Cafodd ei diweddaru ddiwethaf ar 23 Medi 2019.
-
 #session time out
 timeout-dialog.p1=Am resymau diogelwch, cewch eich allgofnodi o’ch cyfrif gwasanaethau asiant ymhen
 
@@ -190,7 +143,7 @@ survey.empty=Dewiswch opsiwn
 #signed-out
 signed-out.header=Rydych wedi cael eich allgofnodi
 signed-out.p1=Nid ydych wedi gwneud dim byd ers {0}, felly rydym wedi’ch allgofnodi er mwyn cadw’ch cyfrif yn ddiogel.
-signed-out.p2=<a href="{0}">Mewngofnodwch eto</a> i ddefnyddio’r gwasanaeth hwn.
+signed-out.p2=<a class="govuk-link" href="{0}">Mewngofnodwch eto</a> i ddefnyddio’r gwasanaeth hwn.
 
 help.title=Help ac arweiniad
 help.heading=Help ac arweiniad
@@ -229,7 +182,7 @@ label.beta.yours=– bydd eich
 
 # Account Details
 account-details.title=Manylion y cyfrif
-account-details.inset=Bydd angen i chi ysgrifennu atom er mwyn newid y manylion hyn. <a href={0} target="_blank" rel="noreferrer noopener">Dysgwch ragor drwy ddarllen yr arweiniad (yn agor tab newydd)</a>. Gallwch ond newid eich manylion os ydych yn gyfarwyddwr, ysgrifennydd cwmni, unig fasnachwr, perchennog neu’n bartner.
+account-details.inset=Bydd angen i chi ysgrifennu atom er mwyn newid y manylion hyn. <a class="govuk-link" href={0} target="_blank" rel="noreferrer noopener">Dysgwch ragor drwy ddarllen yr arweiniad (yn agor tab newydd)</a>. Gallwch ond newid eich manylion os ydych yn gyfarwyddwr, ysgrifennydd cwmni, unig fasnachwr, perchennog neu’n bartner.
 account-details.summary-list.header=Manylion y cyfrif gwasanaethau asiant
 account-details.summary-list.email=Cyfeiriad e-bost
 account-details.summary-list.name=Enw

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -126,53 +126,6 @@ global.error.500.title=Sorry, we are experiencing technical difficulties - 500
 global.error.500.heading=Sorry, we’re experiencing technical difficulties
 global.error.500.message=Please try again in a few minutes.
 
-
-accessibility.statement.title=Accessibility statement for agent services account
-accessibility.statement.h1=Accessibility statement for agent services account
-accessibility.statement.intro.p1=This accessibility statement explains how accessible this service is, what to do if you have difficulty using it, and how to report accessibility problems with the service.
-accessibility.statement.intro.p2=This service is part of the wider GOV.UK website. There is a separate <a href="https://www.gov.uk/help/accessibility">accessibility statement</a> for the main GOV.UK website.
-accessibility.statement.intro.p3=This page only contains information about the agent services account service, available at <a href="https://www.tax.service.gov.uk/agent-subscription/task-list">www.tax.service.gov.uk/agent-subscription/task-list</a>.
-
-accessibility.statement.using.heading=Using this service
-accessibility.statement.using.p1=This service enables you to manage your HMRC agent services account for your tax agent firm.
-accessibility.statement.using.p2=This service is run by HM Revenue and Customs (HMRC). We want as many people as possible to be able to use this service. This means you should be able to:
-accessibility.statement.using.l1=change colours, contrast levels and fonts
-accessibility.statement.using.l2=zoom in up to 300% without the text spilling off the screen
-accessibility.statement.using.l3=get from the start of the service to the end using just a keyboard
-accessibility.statement.using.l4=get from the start of the service to the end using speech recognition software
-accessibility.statement.using.l5=listen to the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
-accessibility.statement.using.p3=We have also made the text in the service as simple as possible to understand.
-accessibility.statement.using.p4=<a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to use if you have a disability.
-
-accessibility.statement.accessible.heading=How accessible this service is
-accessibility.statement.accessible.p1=This service is partially compliant with the <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1 AA standard</a>.
-
-accessibility.statement.whattodo.heading=What to do if you have difficulty using this service
-accessibility.statement.whattodo.p1=If you have difficulty using this service, use the ‘Get help with this page’ link on the page in the online service.
-
-accessibility.statement.reporting.heading=Reporting accessibility problems with this service
-accessibility.statement.reporting.p1=We are always looking to improve the accessibility of this service. If you find any problems that are not listed on this page or think we are not meeting accessibility requirements, report the <a href="{0}" target="_blank">accessibility problem (opens in new tab)</a>.
-
-accessibility.statement.enforcement.heading=What to do if you are not happy with how we respond to your complaint
-accessibility.statement.enforcement.p1=The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you are not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support Service</a> (EASS), or the <a href="https://www.equalityni.org/Home">Equality Commission for Northern Ireland</a> (ECNI) if you live in Northern Ireland.
-
-accessibility.statement.contacting.heading=Contacting us by phone or getting a visit from us in person
-accessibility.statement.contacting.p1=We provide a text relay service if you are deaf, hearing impaired or have a speech impediment.
-accessibility.statement.contacting.p2=We can provide a British Sign Language (BSL) interpreter, or you can arrange a visit from an HMRC advisor to help you complete the service.
-accessibility.statement.contacting.p3=Find out how to <a href="https://www.gov.uk/dealing-hmrc-additional-needs">contact us</a>.
-
-accessibility.statement.technical.heading=Technical information about this service’s accessibility
-accessibility.statement.technical.p1=HMRC is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-accessibility.statement.technical.p2=This service is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1 AA standard</a>.
-
-accessibility.statement.technical.p3=We have carried out an in-house expert review of the service and fixed all known accessibility issues. 
-accessibility.statement.technical.p4=We will arrange a formal external audit of the full service as soon as possible, as part of our roadmap for making sure the service is fully compliant.
-
-accessibility.statement.howtested.heading=How we tested this service
-accessibility.statement.howtested.p1=The service was last tested on 22 August 2019 and was checked for compliance with WCAG 2.1 AA.
-accessibility.statement.howtested.p2=The full service was tested by HMRC and included disabled users.
-accessibility.statement.howtested.p3=This page was prepared on 23 September 2019. It was last updated on 23 September 2019.
-
 #session time out
 timeout-dialog.p1=For security reasons, you will be signed out of your Agent services account in
 
@@ -190,7 +143,7 @@ survey.empty=Please select an option
 #signed-out
 signed-out.header=You have been signed out
 signed-out.p1=You have not done anything for {0}, so we have signed you out to keep your account secure.
-signed-out.p2=<a href="{0}">Sign in again</a> to use this service.
+signed-out.p2=<a class="govuk-link" href="{0}">Sign in again</a> to use this service.
 
 help.title=Help and guidance
 help.heading=Help and guidance
@@ -229,7 +182,7 @@ label.beta.yours=– your
 
 # Account Details
 account-details.title=Account details
-account-details.inset=To change these details you will need to write to us. <a href={0} target="_blank" rel="noreferrer noopener">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.
+account-details.inset=To change these details you will need to write to us. <a class="govuk-link" href={0} target="_blank" rel="noreferrer noopener">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.
 account-details.summary-list.header=Agent services account details
 account-details.summary-list.email=Email address
 account-details.summary-list.name=Name

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -2,6 +2,5 @@
 ->         /agent-services-account      app.Routes
 
 ->         /                            health.Routes
-->         /template                    template.Routes
 
 GET        /admin/metrics               @com.kenshoo.play.metrics.MetricsController.metrics

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
@@ -307,7 +307,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       content should include("Any Town")
       content should include("TF3 4TR")
       content should include("GB")
-      content should include(" To change these details you will need to write to us. <a href=https://www.gov.uk/guidance/change-or-remove-your-authorisations-as-a-tax-agent#changes-you-can-make-in-writing target=\"_blank\" rel=\"noreferrer noopener\">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.")
+      content should include(" To change these details you will need to write to us. <a class=\"govuk-link\" href=https://www.gov.uk/guidance/change-or-remove-your-authorisations-as-a-tax-agent#changes-you-can-make-in-writing target=\"_blank\" rel=\"noreferrer noopener\">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.")
 
     }
 
@@ -326,7 +326,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       content should include(messagesApi("account-details.summary-list.name"))
       content should include(messagesApi("account-details.summary-list.address"))
       content should include(messagesApi("account-details.summary-list.none"))
-      content should include(" To change these details you will need to write to us. <a href=https://www.gov.uk/guidance/change-or-remove-your-authorisations-as-a-tax-agent#changes-you-can-make-in-writing target=\"_blank\" rel=\"noreferrer noopener\">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.")
+      content should include(" To change these details you will need to write to us. <a class=\"govuk-link\" href=https://www.gov.uk/guidance/change-or-remove-your-authorisations-as-a-tax-agent#changes-you-can-make-in-writing target=\"_blank\" rel=\"noreferrer noopener\">Find out more by reading the guidance (opens in new tab)</a>. You can only change your details if you are a director, company secretary, sole trader, proprietor or partner.")
 
       }
 


### PR DESCRIPTION
- remove govuk-template route
- remove accessibility statement keys in messages
- add govuk-link class in places it was missing
- fix focus for welsh language toggle in header

Can whoever checks this pull it down and run it first? I had it working and took screenshots but it's seemingly reverted and trying to figure out what's going on.
<img width="1026" alt="Screenshot 2021-11-03 at 14 30 47" src="https://user-images.githubusercontent.com/62263396/140091792-2e6d9c4e-9481-401f-8c10-ecde4c2b598f.png">
<img width="1021" alt="Screenshot 2021-11-03 at 14 30 56" src="https://user-images.githubusercontent.com/62263396/140091801-ec449673-dd2c-4df8-9808-6f40b48a2153.png">


