### PR TITLE
APB-6743b [CS] amend permissions for /administrators page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,22 @@
 This is the frontend for the Agent Services account page. It is available to agents who have the HMRC-AS-AGENT enrolment, 
 allowing them to access to a range of HMRC digital services.
 
-### Running the tests
+### Manage account vs Your account
+ASA accounts typically hold `credentialRole: "User"`. An agency has at least one admin - historically this login has been shared in smaller agencies.
+
+If they create additional users (creating fresh Government Gateway credentials) through the external service they will be assigned to the same group (same ARN). The additional users can be:
+- "Admin" - credentialRole is User or Admin, Admin is deprecated
+- "Standard" - credentialRole is Assistant
+
+Administrators have access to most ASA functionality, such as sending authorisation requests and managing access groups. They see "Manage account" in the secondary nav bar.
+
+Standard users have limited functionality. They can view the clients lists they are assigned to, and a list of administrators for their agency. They can manage the taxes of clients they have access to. They see "Your account" in the secondary nav bar.
+
+#### Creating additional users (team members)
+
+The link to add users to the agency is in `application.conf` under `user-management.add-user`. It is a redirect through Secure Credentials Platform (SCP). 
+
+## Running the tests
 
     sbt test
 

--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/ManageLandingController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/ManageLandingController.scala
@@ -55,7 +55,7 @@ class ManageLandingController @Inject()(
           Future.successful(Ok(asa_bridging_screen(isAccessGroupEnabled = false)))
         }
       } else {
-        Future.successful(Unauthorized)
+        Future.successful(Forbidden)
       }
     }
   }

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/EACD/asa_bridging_screen.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/EACD/asa_bridging_screen.scala.html
@@ -24,62 +24,33 @@
 
 @import uk.gov.hmrc.agentservicesaccount.controllers.routes
 
-
 @this(main: main, govukButton: GovukButton,link_as_button: link_as_button)
 
+@(isAccessGroupEnabled: Boolean)(implicit msgs: Messages, request: Request[_], appConfig: AppConfig)
 
-@(
-    isAccessGroupEnabled: Boolean // parameters for controller
-)(implicit msgs: Messages, request: Request[_], appConfig: AppConfig)
+@main(pageTitle = msgs("agent-service-bridging.title"), isAdmin = true) {
 
-@main( // laods main page header and footer
-    pageTitle = msgs("agent-service-bridging.title"),
+ <h1 class="govuk-heading-xl">@msgs("agent-service-bridging.title")</h1>
 
-) {
-
+ <p class="govuk-inset-text"> @msgs("agent-service-bridging.p1") </p>
+ <p class="govuk-body"> @msgs("agent-service-bridging.p2") </p>
  @if(isAccessGroupEnabled) {
-  <h1 class="govuk-heading-xl">@msgs("agent-service-bridging.title")</h1>
-
-  <p class="govuk-inset-text"> @msgs("agent-service-bridging.p1") </p>
-  <p class="govuk-body"> @msgs("agent-service-bridging.p2") </p>
   <p class="govuk-body"> @msgs("agent-service-bridging.p3") </p>
   <p class="govuk-body"> @msgs("agent-service-bridging.p4") </p>
-
-
-  <div class="govuk-button-group">
-   @link_as_button(
-    href= routes.AgentServicesController.manageAccount.url,
-    key = "common.continue.manage.account",
-    classes = Some("govuk-button"),
-   )
-
-   @govukButton(Button(name = Some("landing"), classes = "govuk-button--secondary" , content = Text(msgs("common.cancel"))))
-
-  </div>
-
-
-
- }else {
-
-  <h1 class="govuk-heading-xl">@msgs("agent-service-bridging.title")</h1>
-
-  <p class="govuk-inset-text"> @msgs("agent-service-bridging.p1") </p>
-  <p class="govuk-body"> @msgs("agent-service-bridging.p2") </p>
+ } else {
   <p class="govuk-body"> @msgs("agent-service-bridging.p5") </p>
   <p class="govuk-body"> @msgs("agent-service-bridging.p6") </p>
-
-  <div class="govuk-button-group">
-   @link_as_button(
-    href= routes.AgentServicesController.manageAccount.url,
-    key = "common.continue.manage.account",
-    classes = Some("govuk-button")
-   )
-   @govukButton(Button(name = Some("landing"), classes = "govuk-button--secondary" , content = Text(msgs("common.cancel"))))
-
-  </div>
-
-
  }
+
+ <div class="govuk-button-group">
+  @link_as_button(
+  href= routes.AgentServicesController.manageAccount.url,
+  key = "common.continue.manage.account",
+  classes = Some("govuk-button")
+  )
+  @govukButton(Button(name = Some("landing"), classes = "govuk-button--secondary" , content = Text(msgs("common.cancel"))))
+
+ </div>
 
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,11 +14,6 @@
 
 include "frontend.conf"
 customDimension="dimension2"
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
 # An audit connector must be provided.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object AppDependencies {
   private val mongoVer: String = "0.74.0"
-  private val bootstrapVer: String = "7.13.0"
+  private val bootstrapVer: String = "7.15.0"
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % bootstrapVer,
     "uk.gov.hmrc"       %% "play-partials"              % "8.3.0-play-28",
-    "uk.gov.hmrc"       %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
+    "uk.gov.hmrc"       %% "agent-kenshoo-monitoring"   % "5.3.0",
     "uk.gov.hmrc"       %% "agent-mtd-identifiers"      % "1.2.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % mongoVer,
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "6.7.0-play-28"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.typesafe.sbt"  % "sbt-twirl" 		% "1.5.1")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.19")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
@@ -1041,8 +1041,8 @@ class AgentServicesControllerSpec extends BaseISpec {
 
   s"GET on Administrators of your account at url: $adminUrl" should {
 
-    "render static data and list of Admin Users for ARN" in {
-      givenAuthorisedAsAgentWith(arn)
+    "render static data and list of Admin Users for ARN if standard user" in {
+      givenAuthorisedAsAgentWith(arn, isAdmin = false)
       givenArnAllowedOk()
       givenSyncEacdSuccess(Arn(arn))
       givenOptinStatusSuccessReturnsForArn(Arn(arn), OptedInReady)
@@ -1078,6 +1078,14 @@ class AgentServicesControllerSpec extends BaseISpec {
       adminEmails.get(1).text shouldBe "steve@builder.com"
       adminNames.get(2).text shouldBe "Albert Forger"
       adminEmails.get(2).text shouldBe "a.forger@builder.com"
+    }
+
+    "return forbidden for admin users" in {
+      givenAuthorisedAsAgentWith(arn) // isAdmin = true
+
+      val response = await(controller.administrators()(fakeRequest("GET", adminUrl)))
+
+      status(response) shouldBe 403
     }
 
   }


### PR DESCRIPTION
@raw1697 please review 👀 

Changes summary:
- amend permissions for /administrators page
- the asa bridging screen will show "Manage account" instead of "Your account" for admin users
- hide private beta invite from standard users
- add notes for admin vs 'standard' user in README.md