### PR TITLE
APB-7488 [CS] remove beta banner

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/config/AppConfig.scala
@@ -110,7 +110,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val runMode: Option[String] = config.getOptional[String]("run.mode")
   val isDevEnv: Boolean = if (env.mode.equals(Mode.Test)) false else runMode.forall(Mode.Dev.toString.equals)
 
-  val betaFeedbackUrl: String = getString("betaFeedbackUrl")
   val userResearchLink: String = getString("userResearchLink")
 
   val hmrcOnlineGuidanceLink: String = getString("hmrcOnlineGuidanceLink")

--- a/app/uk/gov/hmrc/agentservicesaccount/views/main.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/main.scala.html
@@ -67,9 +67,8 @@
     @hmrcLanguageSelectHelper()
 
     @if(backLinkHref.isDefined) {
-        @govukBackLink(BackLink(
-            href = backLinkHref.get,
-            content = Text(msgs("common.back"))
+        @govukBackLink(BackLink.withDefaultText(
+            href = backLinkHref.get
         ))
     }
 
@@ -90,7 +89,6 @@
         signOutUrl = Some(routes.SignOutController.signOut.url)
     ),
     banners = Banners(
-        phaseBanner = Some(standardBetaBanner(appConfig.betaFeedbackUrl)),
         additionalBannersBlock = additionalBanner
     ),
     templateOverrides = TemplateOverrides(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,23 +14,12 @@
 
 include "frontend.conf"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
-# An audit connector must be     provided.
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
-
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
-
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.agentservicesaccount.ErrorHandler"
@@ -167,9 +156,11 @@ tracking-consent-frontend {
   gtm.container = "b"
 }
 
-contact-frontend.host = "http://localhost:9250"
-contactFormServiceIdentifier = "AOSS"
-betaFeedbackUrl = ${contact-frontend.host}"/contact/beta-feedback?service="${contactFormServiceIdentifier}
+contact-frontend {
+    host = "http://localhost:9250"
+    serviceId = "AOSS"
+}
+
 userResearchLink = "/test-only/agents-ur-banner"
 hmrcOnlineGuidanceLink = "https://www.gov.uk/government/collections/hmrc-online-services-for-agents#hmrc-online-services-for-agents-account"
 hmrcOnlineSignInLink = "https://www.access.service.gov.uk/login/signin/creds"
@@ -206,8 +197,6 @@ gran-perms-max-client-count = 100000
 
 login.continue = "http://localhost:9401"
 bas-gateway.url = "http://localhost:9553/bas-gateway/sign-in"
-
-contact-frontend.serviceId = "AOSS"
 
 accessibility-statement.service-path = "/agent-services-account"
 

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
@@ -181,13 +181,6 @@ class AgentServicesControllerSpec extends BaseISpec {
 
         expectedTitle(html, "Welcome to your agent services account - Agent services account - GOV.UK")
 
-        // beta banner present - only when gran perms enabled?
-        assertElementContainsText(html, cssSelector = "div.govuk-phase-banner a", expectedText = "feedback")
-        assertAttributeValueForElement(
-          element = html.select("div.govuk-phase-banner a").get(0),
-          attributeValue = "http://localhost:9250/contact/beta-feedback?service=AOSS"
-        )
-
         expectedHomeBannerContent(html)
         expectedUrBannerContent(html)
         expectedClientAuthContent(html)


### PR DESCRIPTION
think the reason this was left in was maybe because of access groups? (manage account is the entry point)
agent-permissions-frontend still has the banner, it has been removed everywhere else