### PR TITLE
APB-7547 Refactored error messages and tests

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/UpdateMoneyLaunderingSupervisionController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/UpdateMoneyLaunderingSupervisionController.scala
@@ -40,7 +40,7 @@ class UpdateMoneyLaunderingSupervisionController @Inject()(amlsLoader: AMLSLoade
   private val amlsBodies: Map[String, String] = amlsLoader.load("/amls-no-hmrc.csv")
 
   def showUpdateMoneyLaunderingSupervision: Action[AnyContent] = actions.authActionCheckSuspend.async { implicit request =>
-      val updateAmlsForm = UpdateMoneyLaunderingSupervisionForm.form
+      val updateAmlsForm = UpdateMoneyLaunderingSupervisionForm.form(amlsBodies)
     actions.ifFeatureEnabled(appConfig.enableNonHmrcSupervisoryBody) {
       Ok(updateMoneySupervisionView(updateAmlsForm, amlsBodies)).toFuture
     }
@@ -48,7 +48,7 @@ class UpdateMoneyLaunderingSupervisionController @Inject()(amlsLoader: AMLSLoade
 
   def submitUpdateMoneyLaunderingSupervision: Action[AnyContent] = actions.authActionCheckSuspend.async { implicit request =>
     actions.ifFeatureEnabled(appConfig.enableNonHmrcSupervisoryBody) {
-      UpdateMoneyLaunderingSupervisionForm.form.bindFromRequest().fold(
+      UpdateMoneyLaunderingSupervisionForm.form(amlsBodies).bindFromRequest().fold(
         formWithErrors => {
           Ok(updateMoneySupervisionView(formWithErrors, amlsBodies)).toFuture
         },

--- a/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
@@ -26,7 +26,6 @@ import java.time.LocalDate
 import scala.util.{Failure, Success, Try}
 
 object UpdateMoneyLaunderingSupervisionForm {
-  private val supervisoryBodyRegex = """^[A-Za-z0-9\,\.\'\-\/\ ]{0,200}$""".r
   private val supervisoryNumberRegex = """^[A-Za-z0-9\,\.\'\-\/\ ]{0,200}$""".r // remove all spaces from input before matching to ensure correct digit count
   private val trimmedText = text.transform[String](x => x.trim, x => x)
 
@@ -127,12 +126,12 @@ object UpdateMoneyLaunderingSupervisionForm {
     )
   }
 
-  val form: Form[UpdateMoneyLaunderingSupervisionDetails] =
+  def form(amlsBodies: Map[String, String]): Form[UpdateMoneyLaunderingSupervisionDetails] =
     Form(
       mapping(
         "body" -> trimmedText
           .verifying("update-money-laundering-supervisory.body-codes.error.empty", _.nonEmpty)
-          .verifying("update-money-laundering-supervisory.body-codes.error.invalid", x => supervisoryBodyRegex.matches(x)),
+          .verifying("update-money-laundering-supervisory.body-codes.error.invalid", x => amlsBodies.keys.exists(_ == x) || x.isEmpty),
         "number" -> trimmedText
           .verifying("update-money-laundering-supervisory.reg-number.error.empty", _.nonEmpty)
           .verifying("update-money-laundering-supervisory.reg-number.error.invalid", x => supervisoryNumberRegex.matches(x.replace(" ", ""))),

--- a/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
@@ -17,80 +17,80 @@
 package uk.gov.hmrc.agentservicesaccount.forms
 
 import play.api.data.{Form, FormError}
-import play.api.data.Forms.{mapping, text, of}
+import play.api.data.Forms.{mapping, of, text}
 import play.api.data.format.Formatter
+import play.api.data.validation.{Valid, ValidationResult}
 import uk.gov.hmrc.agentservicesaccount.models.UpdateMoneyLaunderingSupervisionDetails
 
 import java.time.LocalDate
 import scala.util.{Failure, Success, Try}
-
 
 object UpdateMoneyLaunderingSupervisionForm {
   private val supervisoryBodyRegex = """^[A-Za-z0-9\,\.\'\-\/\ ]{0,200}$""".r
   private val supervisoryNumberRegex = """^[A-Za-z0-9\,\.\'\-\/\ ]{0,200}$""".r // remove all spaces from input before matching to ensure correct digit count
   private val trimmedText = text.transform[String](x => x.trim, x => x)
 
-  private def invalidDateCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def invalidDateCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     Try {
       require(year.length == 4, "Year must be 4 digits")
       LocalDate.of(year.toInt, month.toInt, day.toInt)
     } match {
       case Failure(_) => Left("day" -> "update-money-laundering-supervisory.error.date.invalid")
-      case Success(_) => Right("")
+      case Success(_) => Right(Valid)
     }
   }
 
-  private def pastExpiryDateCheck(day: String, month: String, year: String): Either[(String, String), String] = {
-    if (LocalDate.of(year.toInt, month.toInt, day.toInt).isAfter(LocalDate.now())) Right("")
+  private def pastExpiryDateCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
+    if (LocalDate.of(year.toInt, month.toInt, day.toInt).isAfter(LocalDate.now())) Right(Valid)
     else Left("day" -> "update-money-laundering-supervisory.error.date.past")
   }
 
-  private def within13MonthsExpiryDateCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def within13MonthsExpiryDateCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     val futureDate = LocalDate.now().plusMonths(13)
 
-    if (LocalDate.of(year.toInt, month.toInt, day.toInt).isBefore(futureDate)) Right("")
+    if (LocalDate.of(year.toInt, month.toInt, day.toInt).isBefore(futureDate)) Right(Valid)
     else Left("day" -> "update-money-laundering-supervisory.error.date.before")
   }
 
-  private def noDateCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noDateCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (s"$day$month$year".isEmpty) Left("day" -> "update-money-laundering-supervisory.error.date")
-    else Right("")
+    else Right(Valid)
   }
 
-  private def noDayAndMonthCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noDayAndMonthCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.isEmpty && month.isEmpty && year.nonEmpty) {
       Left("day" -> "update-money-laundering-supervisory.error.day-and-month")
-    } else Right("")
+    } else Right(Valid)
   }
 
-  private def noDayAndYearCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noDayAndYearCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.isEmpty && month.nonEmpty && year.isEmpty) {
       Left("day" -> "update-money-laundering-supervisory.error.day-and-year")
-    } else Right("")
+    } else Right(Valid)
   }
 
-  private def noMonthAndYearCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noMonthAndYearCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.nonEmpty && month.isEmpty && year.isEmpty) {
       Left("month" -> "update-money-laundering-supervisory.error.month-and-year")
-    } else Right("")
+    } else Right(Valid)
   }
 
-  private def noDayCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noDayCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.isEmpty && month.nonEmpty && year.nonEmpty) {
       Left("day" -> "update-money-laundering-supervisory.error.day")
-    } else Right("")
+    } else Right(Valid)
   }
 
-  private def noMonthCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noMonthCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.nonEmpty && month.isEmpty && year.nonEmpty) {
       Left("month" -> "update-money-laundering-supervisory.error.month")
-    } else Right("")
+    } else Right(Valid)
   }
 
-  private def noYearCheck(day: String, month: String, year: String): Either[(String, String), String] = {
+  private def noYearCheck(day: String, month: String, year: String): Either[(String, String), ValidationResult] = {
     if (day.nonEmpty && month.nonEmpty && year.isEmpty) {
       Left("year" -> "update-money-laundering-supervisory.error.year")
-    } else Right("")
+    } else Right(Valid)
   }
 
   implicit val dateFormatter: Formatter[LocalDate] = new Formatter[LocalDate] {

--- a/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionForm.scala
@@ -74,14 +74,55 @@ object UpdateMoneyLaunderingSupervisionForm {
       } else Valid
   }
 
-//  private val missingDayAndMonth: String = {
-//
-//    //val flag = true
-//   // val constraint[(String, String, String)] = trim.nonEmpty
-//
-//    if (true) "update-money-laundering-supervisory.error.day"
-//    else ("update-money-laundering-supervisory.error.day-and-month")
-//  }
+  private val noDayAndMonthConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.isEmpty && month.isEmpty && year.nonEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.day-and-month"))
+      } else Valid
+  }
+  private val noDayAndYearConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.isEmpty && month.nonEmpty && year.isEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.day-and-year"))
+      } else Valid
+  }
+  private val noMonthAndYearConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.nonEmpty && month.isEmpty && year.isEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.month-and-year"))
+      } else Valid
+  }
+
+  private val noDayConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.isEmpty && month.nonEmpty && year.nonEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.day"))
+      } else Valid
+  }
+  private val noMonthConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.nonEmpty && month.isEmpty && year.nonEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.month"))
+      } else Valid
+  }
+  private val noYearConstraint: Constraint[(String, String, String)] = Constraint[(String, String, String)] {
+    data: (String, String, String) =>
+      val (day, month, year) = data
+
+      if (day.nonEmpty && month.nonEmpty && year.isEmpty) {
+        Invalid(ValidationError("update-money-laundering-supervisory.error.year"))
+      } else Valid
+  }
 
   val form: Form[UpdateMoneyLaunderingSupervisionDetails] =
     Form(
@@ -96,36 +137,22 @@ object UpdateMoneyLaunderingSupervisionForm {
           tuple(
             "day" -> trimmedText,
             "month" -> trimmedText,
-            "year" -> trimmedText,
+            "year" -> trimmedText
 
-          ).verifying(checkOneAtATime(Seq(noDateConstraint, invalidDateConstraint, pastExpiryDateConstraint, within13MonthsExpiryDateConstraint)))
+          ).verifying(checkOneAtATime(Seq(
+            noDateConstraint,
+            noDayAndMonthConstraint,
+            noDayAndYearConstraint,
+            noMonthAndYearConstraint,
+            noDayConstraint,
+            noMonthConstraint,
+            noYearConstraint,
+            invalidDateConstraint,
+            pastExpiryDateConstraint,
+            within13MonthsExpiryDateConstraint)))
             .transform[LocalDate](
               { case (d, m, y) => LocalDate.of( y.trim.toInt, m.trim.toInt, d.trim.toInt) },
               (date: LocalDate) => (date.getDayOfMonth.toString, date.getMonthValue.toString, date.getYear.toString))
       )(UpdateMoneyLaunderingSupervisionDetails.apply)(UpdateMoneyLaunderingSupervisionDetails.unapply)
       )
 }
-
-/*
-val form: Form[UpdateMoneyLaunderingSupervisionDetails] =
-  Form(
-    mapping(
-      "body" -> trimmedText
-        .verifying("update-money-laundering-supervisory.body-codes.error.empty", _.nonEmpty)
-        .verifying("update-money-laundering-supervisory.body-codes.error.invalid", x => supervisoryBodyRegex.matches(x)),
-      "number" -> trimmedText
-        .verifying("update-money-laundering-supervisory.reg-number.error.empty", _.nonEmpty)
-        .verifying("update-money-laundering-supervisory.reg-number.error.invalid", x => supervisoryNumberRegex.matches(x.replace(" ", ""))),
-      "endDate" ->
-        tuple(
-          "day" -> text.verifying("update-money-laundering-supervisory.error.day", d => d.trim.nonEmpty || d.matches("^[0-9]{1,2}$")),
-          "month" -> text.verifying("update-money-laundering-supervisory.error.month", m => m.trim.nonEmpty || m.matches("^[0-9]{1,2}$")),
-          "year" -> text.verifying("update-money-laundering-supervisory.error.year", y => y.trim.nonEmpty || y.matches("^[0-9]{1,4}$")),
-
-        ).verifying(checkOneAtATime(Seq(invalidDateConstraint, pastExpiryDateConstraint, within13MonthsExpiryDateConstraint)))
-          .transform[LocalDate](
-            { case (d, m, y) => LocalDate.of( y.trim.toInt, m.trim.toInt, d.trim.toInt) },
-            (date: LocalDate) => (date.getDayOfMonth.toString, date.getMonthValue.toString, date.getYear.toString))
-    )(UpdateMoneyLaunderingSupervisionDetails.apply)(UpdateMoneyLaunderingSupervisionDetails.unapply)
-    )
- */

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
@@ -59,6 +59,11 @@
         "month-field-error"
 }
 
+@DayAbdMonthFieldError = @{
+    if(form("endDate.day").hasErrors && form("endDate.month").hasErrors)
+        "day-month-field-error"
+}
+
 @YearFieldError = @{
     if(form("endDate.year").hasErrors)
         "year-field-error"

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
@@ -49,36 +49,22 @@
         <script @{CSPNonce.attr} src="@controllers.routes.Assets.at("javascripts/accessible-autocomplete-polyfill.js")"></script>
     }
 
-@DayFieldError = @{
-    if(form("endDate.day").hasErrors)
-        "day-field-error"
-}
-
-@MonthFieldError = @{
-    if(form("endDate.month").hasErrors)
-        "month-field-error"
-}
-
-@DayAbdMonthFieldError = @{
-    if(form("endDate.day").hasErrors && form("endDate.month").hasErrors)
-        "day-month-field-error"
-}
-
-@YearFieldError = @{
-    if(form("endDate.year").hasErrors)
-        "year-field-error"
-}
-
-@DateFieldErrorsAll = @{
-    if(form("endDate").hasErrors && !form("endDate.day").hasErrors && !form("endDate.month").hasErrors && !form("endDate.year").hasErrors)
-        "date-field-errors-all"
-}
-
 @dateFormWithRefinedErrors = @{
-    form.copy(errors = form.errors.filterNot(error => error.message == "" || error.key.contains("endDate.day")
-            || error.key.contains("endDate.month") || error.key.contains("endDate.year")))
+    form.copy(errors = form.errors.map(formError =>
+        if(formError.key.contains("endDate")) {
+            formError.message match {
+                case "update-money-laundering-supervisory.error.year" =>
+                    formError.copy(key = "endDate.year")
+                case "update-money-laundering-supervisory.error.month" =>
+                    formError.copy(key = "endDate.month")
+                case "update-money-laundering-supervisory.error.month-and-year" =>
+                    formError.copy(key = "endDate.month")
+                case _ =>
+                    formError.copy(key = "endDate.day")
+            }
+        } else formError
+    ))
 }
-
 @fieldsetHtml = {
     @govukSelect(Select(
         id = "body",
@@ -135,9 +121,8 @@
     additionalScripts = Some(scripts)
 ) {
     @if(form.hasErrors) {
-        @govukErrorSummary(ErrorSummary(errorList = form.errors.asTextErrorLinks, title = Text(msgs("survey.error.summary"))))
+        @govukErrorSummary(ErrorSummary(errorList = dateFormWithRefinedErrors.errors.asTextErrorLinks, title = Text(msgs("survey.error.summary"))))
     }
-
     @formWithCSRF(action = routes.UpdateMoneyLaunderingSupervisionController.submitUpdateMoneyLaunderingSupervision) {
         @govukFieldset(Fieldset(
             html = fieldsetHtml,

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/update_money_laundering_supervision_details.scala.html
@@ -49,22 +49,6 @@
         <script @{CSPNonce.attr} src="@controllers.routes.Assets.at("javascripts/accessible-autocomplete-polyfill.js")"></script>
     }
 
-@dateFormWithRefinedErrors = @{
-    form.copy(errors = form.errors.map(formError =>
-        if(formError.key.contains("endDate")) {
-            formError.message match {
-                case "update-money-laundering-supervisory.error.year" =>
-                    formError.copy(key = "endDate.year")
-                case "update-money-laundering-supervisory.error.month" =>
-                    formError.copy(key = "endDate.month")
-                case "update-money-laundering-supervisory.error.month-and-year" =>
-                    formError.copy(key = "endDate.month")
-                case _ =>
-                    formError.copy(key = "endDate.day")
-            }
-        } else formError
-    ))
-}
 @fieldsetHtml = {
     @govukSelect(Select(
         id = "body",
@@ -121,7 +105,7 @@
     additionalScripts = Some(scripts)
 ) {
     @if(form.hasErrors) {
-        @govukErrorSummary(ErrorSummary(errorList = dateFormWithRefinedErrors.errors.asTextErrorLinks, title = Text(msgs("survey.error.summary"))))
+        @govukErrorSummary(ErrorSummary().withFormErrorsAsText(form))
     }
     @formWithCSRF(action = routes.UpdateMoneyLaunderingSupervisionController.submitUpdateMoneyLaunderingSupervision) {
         @govukFieldset(Fieldset(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -81,5 +81,5 @@ GET        /manage-account/money-laundering-supervision      @uk.gov.hmrc.agents
 GET        /manage-account/money-laundering-supervisory-body @uk.gov.hmrc.agentservicesaccount.controllers.AmlsIsHmrcController.showAmlsIsHmrc
 POST       /manage-account/money-laundering-supervisory-body @uk.gov.hmrc.agentservicesaccount.controllers.AmlsIsHmrcController.submitAmlsIsHmrc
 
-GET       /manage-account/update-money-laundering-supervision            @uk.gov.hmrc.agentservicesaccount.controllers.UpdateMoneyLaunderingSupervisionController.showUpdateMoneyLaunderingSupervision
-POST      /manage-account/update-money-laundering-supervision            @uk.gov.hmrc.agentservicesaccount.controllers.UpdateMoneyLaunderingSupervisionController.submitUpdateMoneyLaunderingSupervision
+GET        /manage-account/update-money-laundering-supervision            @uk.gov.hmrc.agentservicesaccount.controllers.UpdateMoneyLaunderingSupervisionController.showUpdateMoneyLaunderingSupervision
+POST       /manage-account/update-money-laundering-supervision            @uk.gov.hmrc.agentservicesaccount.controllers.UpdateMoneyLaunderingSupervisionController.submitUpdateMoneyLaunderingSupervision

--- a/conf/messages
+++ b/conf/messages
@@ -540,10 +540,13 @@ amls.enter-renewal-registration.number.h1=Your registration number
 amls.enter-renewal-body.h1=Name of money laundering supervisory body
 
 #AMLS Errors
+update-money-laundering-supervisory.error.date=Enter your next registration renewal date
 update-money-laundering-supervisory.error.day=Your next registration renewal date must include a day
 update-money-laundering-supervisory.error.month=Your next registration renewal date must include a month
 update-money-laundering-supervisory.error.year=Your next registration renewal date must include a year
 update-money-laundering-supervisory.error.day-and-month=Your next registration renewal date must include a day and a month
+update-money-laundering-supervisory.error.day-and-year=Your next registration renewal date must include a day and a year
+update-money-laundering-supervisory.error.month-and-year=Your next registration renewal date must include a month and a year
 
 update-money-laundering-supervisory.error.date.invalid=Enter a real date
 update-money-laundering-supervisory.error.date.past=Your next registration renewal date must be in the future

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -540,10 +540,13 @@ amls.enter-renewal-registration.number.h1=Your registration number TBC
 amls.enter-renewal-body.h1=Name of money laundering supervisory body TBC
 
 #AMLS Errors
+update-money-laundering-supervisory.error.date=Enter your next registration renewal date TBC
 update-money-laundering-supervisory.error.day=Your next registration renewal date must include a day TBC
 update-money-laundering-supervisory.error.month=Your next registration renewal date must include a month TBC
 update-money-laundering-supervisory.error.year=Your next registration renewal date must include a year TBC
 update-money-laundering-supervisory.error.day-and-month=Your next registration renewal date must include a day and a month TBC
+update-money-laundering-supervisory.error.day-and-year=Your next registration renewal date must include a day and a year TBC
+update-money-laundering-supervisory.error.month-and-year=Your next registration renewal date must include a month and a year TBC
 
 update-money-laundering-supervisory.error.date.invalid=Enter a real date TBC
 update-money-laundering-supervisory.error.date.past=Your next registration renewal date must be in the future TBC

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/UpdateMoneyLaunderingSupervisionControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/UpdateMoneyLaunderingSupervisionControllerSpec.scala
@@ -135,7 +135,7 @@ class UpdateMoneyLaunderingSupervisionControllerSpec extends PlaySpec
     "redirect to manage-account/update-money-laundering-supervision" in new Setup {
       givenAuthorisedAgent(User)
       givenNotSuspended()
-      mockAmlsLoader.load("/amls-no-hmrc.csv") returns Map("test" -> "test")
+      mockAmlsLoader.load("/amls-no-hmrc.csv") returns Map("AAA" -> "test")
 
       mockAppConfig.enableNonHmrcSupervisoryBody returns true
       view.apply(*[Form[UpdateMoneyLaunderingSupervisionDetails]], *[Map[String, String]])(*[Messages], *[Request[Any]], *[AppConfig]) returns Html("")
@@ -160,6 +160,8 @@ class UpdateMoneyLaunderingSupervisionControllerSpec extends PlaySpec
     "return form with errors" in new Setup {
       givenAuthorisedAgent(User)
       givenNotSuspended()
+      mockAmlsLoader.load("/amls-no-hmrc.csv") returns Map("AAA" -> "test")
+
       mockAppConfig.enableNonHmrcSupervisoryBody returns true
       view.apply(*[Form[UpdateMoneyLaunderingSupervisionDetails]], *[Map[String, String]])(*[Messages], *[Request[Any]], *[AppConfig]) returns Html("")
 

--- a/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
@@ -74,6 +74,84 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       println(validatedForm.errors.head.key)
       validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date"
     }
+    "This should throw an error when day is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> "",
+        endDateMonth -> local_past_date_stub.getMonthValue.toString,
+        endDateYear -> local_past_date_stub.getYear.toString,
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day"
+    }
+    "This should throw an error when month is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> local_past_date_stub.getDayOfMonth.toString,
+        endDateMonth -> "",
+        endDateYear -> local_past_date_stub.getYear.toString,
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.month"
+    }
+    "This should throw an error when year is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> local_past_date_stub.getDayOfMonth.toString,
+        endDateMonth -> local_past_date_stub.getMonthValue.toString,
+        endDateYear -> "",
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.year"
+    }
+    "This should throw an error when day and month is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> "",
+        endDateMonth -> "",
+        endDateYear -> local_valid_date_stub.getYear.toString,
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day-and-month"
+    }
+    "This should throw an error when day and year is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> "",
+        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
+        endDateYear -> "",
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day-and-year"
+    }
+    "This should throw an error when month and year is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
+        endDateMonth -> "",
+        endDateYear -> "",
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.month-and-year"
+    }
     s"error when $bodyField and $numberField and $endDateField are empty" in {
       val params = Map(
         bodyField -> "",

--- a/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
@@ -18,12 +18,11 @@ package uk.gov.hmrc.agentservicesaccount.forms
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.agentservicesaccount.models.UpdateMoneyLaunderingSupervisionDetails
 
 import java.time.LocalDate
 
-class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers {
 
   val bodyField = "body"
   val numberField = "number"
@@ -36,117 +35,47 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
   val local_future_date_stub: LocalDate = LocalDate.now.plusYears(2)
   val local_past_date_stub: LocalDate = LocalDate.now()
 
+  val KNOWN_BODY_CODE = "KNOWN-CODE"
+  val UNKNOWN_BODY_CODE = "UNKNOWN-CODE"
+  val knownSupervisoryBodies: Map[String, String] = Map(KNOWN_BODY_CODE -> "body description")
+
+  val validFormSubmission: Map[String, String] = Map(
+    bodyField -> KNOWN_BODY_CODE,
+    numberField -> "1122334455",
+    endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
+    endDateMonth -> local_valid_date_stub.getMonthValue.toString,
+    endDateYear -> local_valid_date_stub.getYear.toString,
+  )
+
+  val formSubmissionWithNoRegDate: Map[String, String] = Map(
+    bodyField -> KNOWN_BODY_CODE,
+    numberField -> "1122334455",
+    endDateDay -> "",
+    endDateMonth -> "",
+    endDateYear -> ""
+  )
+
+  private def invalidateFormSubmission(badData: (String, String)): Map[String, String] =
+    (validFormSubmission - badData._1) ++ List(badData)
+
+  private def partialDateFormSubmission(datePart: (String, String)): Map[String, String] =
+    (formSubmissionWithNoRegDate - datePart._1) ++ List(datePart)
+
   "UpdateMoneyLaunderingSupervisionForm binding" should {
-    "be successful when not empty" in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear-> local_valid_date_stub.getYear.toString,
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+    "be successful valid data is submitted" in {
+      val params = validFormSubmission
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.value shouldBe
-        Some(UpdateMoneyLaunderingSupervisionDetails("Blah alkfh", "1122334455", local_valid_date_stub))
+        Some(UpdateMoneyLaunderingSupervisionDetails(KNOWN_BODY_CODE, "1122334455", local_valid_date_stub))
     }
     "get form data from a completed 'UpdateMoneyLaunderingSupervisionDetails' model" in {
-      val model = UpdateMoneyLaunderingSupervisionDetails("Blah alkfh", "1122334455", local_past_date_stub)
-      val form = UpdateMoneyLaunderingSupervisionForm.form.fill(model)
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> local_past_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_past_date_stub.getMonthValue.toString,
-        endDateYear -> local_past_date_stub.getYear.toString,
-      )
+      val model = UpdateMoneyLaunderingSupervisionDetails(KNOWN_BODY_CODE, "1122334455", local_valid_date_stub)
+      val form = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).fill(model)
+      val params = validFormSubmission
       form.data shouldBe params
     }
-    "This should throw an error when date is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> "",
-        endDateMonth -> "",
-        endDateYear -> "",
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date"
-    }
-    "This should throw an error when day is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> "",
-        endDateMonth -> local_past_date_stub.getMonthValue.toString,
-        endDateYear -> local_past_date_stub.getYear.toString,
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day"
-    }
-    "This should throw an error when month is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> local_past_date_stub.getDayOfMonth.toString,
-        endDateMonth -> "",
-        endDateYear -> local_past_date_stub.getYear.toString,
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
-    }
-    "This should throw an error when year is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> local_past_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_past_date_stub.getMonthValue.toString,
-        endDateYear -> "",
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
-    }
-    "This should throw an error when day and month is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> "",
-        endDateMonth -> "",
-        endDateYear -> local_valid_date_stub.getYear.toString,
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-month"
-    }
-    "This should throw an error when day and year is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> "",
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear -> "",
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-year"
-    }
-    "This should throw an error when month and year is not supplied " in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> "",
-        endDateYear -> "",
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
-      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month-and-year"
-    }
-    s"error when $bodyField and $numberField and $endDateField are empty" in {
+
+    s"error when no data is submitted" in {
       val params = Map(
         bodyField -> "",
         numberField -> "",
@@ -154,120 +83,139 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
         endDateMonth -> "",
         endDateYear -> ""
       )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.length shouldBe 3
       validatedForm.error(bodyField).get.message shouldBe "update-money-laundering-supervisory.body-codes.error.empty"
       validatedForm.error(numberField).get.message shouldBe "update-money-laundering-supervisory.reg-number.error.empty"
       validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date"
-      validatedForm.errors.length shouldBe 3
     }
-    s"error when $bodyField is invalid" in {
-      val params = Map(
-        bodyField -> "###",
-        numberField -> "11223344",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear-> local_valid_date_stub.getYear.toString
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+
+    s"error when the supervisory body is not submitted" in {
+      val params = invalidateFormSubmission(bodyField -> "")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(bodyField).get.message shouldBe "update-money-laundering-supervisory.body-codes.error.empty"
+    }
+    s"error when the supervisory body is not in the provided list" in {
+      val params = invalidateFormSubmission(bodyField -> UNKNOWN_BODY_CODE)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.errors.size shouldBe 1
       validatedForm.error(bodyField).get.message shouldBe "update-money-laundering-supervisory.body-codes.error.invalid"
     }
-    s"error when $numberField is invalid" in {
-      val params = Map(
-        bodyField -> "AABBCC",
-        numberField -> "###",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear-> local_valid_date_stub.getYear.toString
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+
+    s"error when the registration number is not submitted" in {
+      val params = invalidateFormSubmission(numberField -> "")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(numberField).get.message shouldBe "update-money-laundering-supervisory.reg-number.error.empty"
+    }
+    s"error when the registration number is invalid" in {
+      val params = invalidateFormSubmission(numberField -> "###")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.errors.size shouldBe 1
       validatedForm.error(numberField).get.message shouldBe "update-money-laundering-supervisory.reg-number.error.invalid"
     }
-    s"error when $endDateDay is invalid" in {
-      val params = Map(
-        bodyField -> "AABBCC",
-        numberField -> "11223344",
-        endDateDay -> "222",
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear -> local_valid_date_stub.getYear.toString
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
+
+    "error when date is not supplied" in {
+      val params = formSubmissionWithNoRegDate
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "day" check msg
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date"
     }
-    s"error when $endDateMonth is invalid" in {
-      val params = Map(
-        bodyField -> "AABBCC",
-        numberField -> "11223344",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> "333",
-        endDateYear -> local_valid_date_stub.getYear.toString
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
+    "error when day is not supplied" in {
+      val params = invalidateFormSubmission(endDateDay -> "")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" //"month" check msg
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day"
     }
-    s"error when $endDateYear is invalid" in {
-      val params = Map(
-        bodyField -> "AABBCC",
-        numberField -> "11223344",
-        endDateDay -> local_valid_date_stub.getDayOfMonth.toString,
-        endDateMonth -> local_valid_date_stub.getMonthValue.toString,
-        endDateYear -> "###"
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.hasErrors shouldBe true
+    "error when month is not supplied" in {
+      val params = invalidateFormSubmission(endDateMonth -> "")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "year" check msg
+      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
     }
-    s"error when $endDateField passes the regex format however is an invalid date" in{
+    "error when year is not supplied" in {
+      val params = invalidateFormSubmission(endDateYear -> "")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
+    }
+    "error when day and month is not supplied" in {
+      val params = partialDateFormSubmission(endDateYear -> local_valid_date_stub.getYear.toString)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-month"
+    }
+    "error when day and year is not supplied" in {
+      val params = partialDateFormSubmission(endDateMonth -> local_valid_date_stub.getMonthValue.toString)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-year"
+    }
+    "error when month and year is not supplied" in {
+      val params = partialDateFormSubmission(endDateDay -> local_valid_date_stub.getDayOfMonth.toString)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month-and-year"
+    }
+    s"error when the day is invalid" in {
+      val params = invalidateFormSubmission(endDateDay -> "222")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+    }
+    s"error when the month is invalid" in {
+      val params = invalidateFormSubmission(endDateMonth -> "333")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+    }
+    s"error when the year is invalid" in {
+      val params = invalidateFormSubmission(endDateYear -> "###")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+    }
+    s"error when the registration date is not a real date" in {
       val params = Map(
-        bodyField -> "Blah alkfh",
+        bodyField -> KNOWN_BODY_CODE,
         numberField -> "1122334455",
         endDateDay -> "31",
         endDateMonth -> "02",
         endDateYear -> local_valid_date_stub.getYear.toString
       )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-        validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
-    }
-
-    s"error when $endDateField passes the regex format however is an invalid date (edge case)" in {
-      val params = Map(
-        bodyField -> "Blah alkfh",
-        numberField -> "1122334455",
-        endDateDay -> "0",
-        endDateMonth -> "-1",
-        endDateYear -> local_valid_date_stub.getYear.toString
-      )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
       validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
     }
-
-    s"error when $endDateField range isn't within 13 Months of today's date" in {
+    s"error when the registration date is an invalid date (edge case)" in {
+      val params = invalidateFormSubmission(endDateMonth -> "-1")
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+    }
+    s"error when the registration date is more than 13 Months in the future" in {
       val params = Map(
-        bodyField -> "Blah alkfh",
+        bodyField -> KNOWN_BODY_CODE,
         numberField -> "1122334455",
         endDateDay -> local_future_date_stub.getDayOfMonth.toString,
         endDateMonth -> local_future_date_stub.getMonthValue.toString,
         endDateYear -> local_future_date_stub.getYear.toString
       )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
       validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.before"
     }
-    s"error when $endDateField is before today's date" in {
+    s"error when the registration date is before today's date" in {
       val params = Map(
-        bodyField -> "Blah alkfh",
+        bodyField -> KNOWN_BODY_CODE,
         numberField -> "1122334455",
         endDateDay -> local_past_date_stub.getDayOfMonth.toString,
         endDateMonth -> local_past_date_stub.getMonthValue.toString,
         endDateYear -> local_past_date_stub.getYear.toString,
       )
-      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form(knownSupervisoryBodies).bind(params)
+      validatedForm.errors.size shouldBe 1
       validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.past"
     }
   }

--- a/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
@@ -71,8 +71,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date"
     }
     "This should throw an error when day is not supplied " in {
       val params = Map(
@@ -84,8 +83,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day"
     }
     "This should throw an error when month is not supplied " in {
       val params = Map(
@@ -98,7 +96,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
       println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.month"
+      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
     }
     "This should throw an error when year is not supplied " in {
       val params = Map(
@@ -110,8 +108,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.year"
+      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
     }
     "This should throw an error when day and month is not supplied " in {
       val params = Map(
@@ -123,8 +120,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day-and-month"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-month"
     }
     "This should throw an error when day and year is not supplied " in {
       val params = Map(
@@ -136,8 +132,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.day-and-year"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day-and-year"
     }
     "This should throw an error when month and year is not supplied " in {
       val params = Map(
@@ -149,8 +144,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
-      println(validatedForm.errors.head.key)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.month-and-year"
+      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month-and-year"
     }
     s"error when $bodyField and $numberField and $endDateField are empty" in {
       val params = Map(
@@ -164,9 +158,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       validatedForm.hasErrors shouldBe true
       validatedForm.error(bodyField).get.message shouldBe "update-money-laundering-supervisory.body-codes.error.empty"
       validatedForm.error(numberField).get.message shouldBe "update-money-laundering-supervisory.reg-number.error.empty"
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date"
-//      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
-//      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date"
       validatedForm.errors.length shouldBe 3
     }
     s"error when $bodyField is invalid" in {
@@ -204,7 +196,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "day" check msg
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "day" check msg
     }
     s"error when $endDateMonth is invalid" in {
       val params = Map(
@@ -217,7 +209,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" //"month" check msg
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" //"month" check msg
     }
     s"error when $endDateYear is invalid" in {
       val params = Map(
@@ -230,7 +222,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm.errors.size shouldBe 1
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "year" check msg
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid" // "year" check msg
     }
     s"error when $endDateField passes the regex format however is an invalid date" in{
       val params = Map(
@@ -241,7 +233,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
         endDateYear -> local_valid_date_stub.getYear.toString
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-        validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+        validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
     }
 
     s"error when $endDateField passes the regex format however is an invalid date (edge case)" in {
@@ -253,7 +245,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
         endDateYear -> local_valid_date_stub.getYear.toString
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.invalid"
     }
 
     s"error when $endDateField range isn't within 13 Months of today's date" in {
@@ -265,7 +257,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
         endDateYear -> local_future_date_stub.getYear.toString
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.before"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.before"
     }
     s"error when $endDateField is before today's date" in {
       val params = Map(
@@ -276,7 +268,7 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
         endDateYear -> local_past_date_stub.getYear.toString,
       )
       val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
-      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date.past"
+      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.date.past"
     }
   }
 }

--- a/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/forms/UpdateMoneyLaunderingSupervisionFormSpec.scala
@@ -61,6 +61,19 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       )
       form.data shouldBe params
     }
+    "This should throw an error when date is not supplied " in {
+      val params = Map(
+        bodyField -> "Blah alkfh",
+        numberField -> "1122334455",
+        endDateDay -> "",
+        endDateMonth -> "",
+        endDateYear -> "",
+      )
+      val validatedForm = UpdateMoneyLaunderingSupervisionForm.form.bind(params)
+      validatedForm.hasErrors shouldBe true
+      println(validatedForm.errors.head.key)
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date"
+    }
     s"error when $bodyField and $numberField and $endDateField are empty" in {
       val params = Map(
         bodyField -> "",
@@ -73,10 +86,10 @@ class UpdateMoneyLaunderingSupervisionFormSpec extends AnyWordSpec with Matchers
       validatedForm.hasErrors shouldBe true
       validatedForm.error(bodyField).get.message shouldBe "update-money-laundering-supervisory.body-codes.error.empty"
       validatedForm.error(numberField).get.message shouldBe "update-money-laundering-supervisory.reg-number.error.empty"
-      validatedForm.error(endDateDay).get.message shouldBe "update-money-laundering-supervisory.error.day"
-      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
-      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
-      validatedForm.errors.length shouldBe 5
+      validatedForm.error(endDateField).get.message shouldBe "update-money-laundering-supervisory.error.date"
+//      validatedForm.error(endDateMonth).get.message shouldBe "update-money-laundering-supervisory.error.month"
+//      validatedForm.error(endDateYear).get.message shouldBe "update-money-laundering-supervisory.error.year"
+      validatedForm.errors.length shouldBe 3
     }
     s"error when $bodyField is invalid" in {
       val params = Map(

--- a/test/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/UpdateMoneyLaunderingSupervisionDetailsViewSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/views/pages/AMLS/UpdateMoneyLaunderingSupervisionDetailsViewSpec.scala
@@ -38,9 +38,10 @@ class UpdateMoneyLaunderingSupervisionDetailsViewSpec extends BaseISpec {
   val view: update_money_laundering_supervision_details = app.injector.instanceOf[update_money_laundering_supervision_details]
   val messages: Messages = MessagesImpl(lang, messagesApi)
 
-  val form: Form[UpdateMoneyLaunderingSupervisionDetails] = UpdateMoneyLaunderingSupervisionForm.form
+  val knownBodies: Map[String, String] = Map("AA" -> "AgentService")
+  val form: Form[UpdateMoneyLaunderingSupervisionDetails] = UpdateMoneyLaunderingSupervisionForm.form(knownBodies)
   val formWithErrors: Form[UpdateMoneyLaunderingSupervisionDetails] =
-    UpdateMoneyLaunderingSupervisionForm.form
+    UpdateMoneyLaunderingSupervisionForm.form(knownBodies)
       .withError(key = "number", message = "update-money-laundering-supervisory.reg-number.error.empty")
       .withError(key = "body", message = "update-money-laundering-supervisory.body-codes.error.empty")
       .withError(key = "endDate", message = "update-money-laundering-supervisory.error.date.invalid")
@@ -49,7 +50,7 @@ class UpdateMoneyLaunderingSupervisionDetailsViewSpec extends BaseISpec {
 
   "update_money_laundering_supervision_details view" when {
     "first viewing page" should {
-      val doc: Document = Jsoup.parse(view.apply(form, Map[String, String](elems = "AA" -> "AgentService"))(messages, FakeRequest(), appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(form, knownBodies)(messages, FakeRequest(), appConfig).body)
 
       "display the correct page title" in {
         doc.title() mustBe "What are your money laundering supervision registration details? - Agent services account - GOV.UK"
@@ -88,7 +89,7 @@ class UpdateMoneyLaunderingSupervisionDetailsViewSpec extends BaseISpec {
       }
     }
     "form is submitted with errors should" should {
-      val doc: Document = Jsoup.parse(view.apply(formWithErrors, Map[String, String](elems = "AA" -> "AgentService"))(messages, FakeRequest(), appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(formWithErrors, knownBodies)(messages, FakeRequest(), appConfig).body)
 
       "display the correct page title (with error prefix)" in {
         doc.title() mustBe "Error: What are your money laundering supervision registration details? - Agent services account - GOV.UK"


### PR DESCRIPTION
This is a build on #423 

- Form now maps date errors to the correct keys
- Redundant [date] error message mapping logic removed
- Tests now check errors are assigned to the correct date form keys
- Removed `println` statements from form tests