### PR TITLE
Added parsing tests for AmlsStatus and reworked class names

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector, AgentPermissionsConnector, AgentUserClientDetailsConnector}
 import uk.gov.hmrc.agentservicesaccount.models.AmlsStatus
-import uk.gov.hmrc.agentservicesaccount.models.AmlsStatuses._
+import uk.gov.hmrc.agentservicesaccount.models.AmlsStatus._
 import uk.gov.hmrc.agentservicesaccount.views.html.pages._
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.assistant.{administrators, your_account}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/app/uk/gov/hmrc/agentservicesaccount/models/AmlsStatus.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/models/AmlsStatus.scala
@@ -16,31 +16,22 @@
 
 package uk.gov.hmrc.agentservicesaccount.models
 
-import enumeratum.{Enum, EnumEntry}
-import play.api.libs.json.Format
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.mvc.QueryStringBindable
-import uk.gov.hmrc.agentservicesaccount.utils.{EnumFormat, ValueClassBinder}
-
-import scala.collection.immutable
+import uk.gov.hmrc.agentservicesaccount.utils.ValueClassBinder
 
 sealed trait AmlsStatus extends EnumEntry
 
-object AmlsStatus {
-  implicit val format: Format[AmlsStatus] = EnumFormat(AmlsStatuses)
+object AmlsStatus extends Enum[AmlsStatus] with PlayJsonEnum[AmlsStatus] {
   implicit val queryBindable: QueryStringBindable[AmlsStatus] = ValueClassBinder.queryStringValueBinder[AmlsStatus](_.entryName)
-}
 
-object AmlsStatuses  extends Enum[AmlsStatus] {
+  val values: IndexedSeq[AmlsStatus] = findValues
+
   final case object NoAmlsDetailsNonUK extends AmlsStatus
   final case object ValidAmlsNonUK extends AmlsStatus
-
   final case object NoAmlsDetailsUK extends AmlsStatus
   final case object ValidAmlsDetailsUK extends AmlsStatus
   final case object ExpiredAmlsDetailsUK extends AmlsStatus
-
-  final case object PendingAmlsDetails  extends AmlsStatus
-  final case object PendingAmlsDetailsRejected  extends AmlsStatus
-
-  override def values: immutable.IndexedSeq[AmlsStatus] = findValues
-
+  final case object PendingAmlsDetails extends AmlsStatus
+  final case object PendingAmlsDetailsRejected extends AmlsStatus
 }

--- a/app/uk/gov/hmrc/agentservicesaccount/models/ModelExtensionMethods.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/models/ModelExtensionMethods.scala
@@ -20,53 +20,53 @@ object ModelExtensionMethods {
   implicit class AmlsStatusExt(val amlsStatus: AmlsStatus) {
 
     def isUkAgent(): Boolean = amlsStatus match {
-      case AmlsStatuses.NoAmlsDetailsUK => true
-      case AmlsStatuses.ValidAmlsDetailsUK => true
-      case AmlsStatuses.ExpiredAmlsDetailsUK => true
-      case AmlsStatuses.PendingAmlsDetails => true
-      case AmlsStatuses.PendingAmlsDetailsRejected => true
-      case AmlsStatuses.NoAmlsDetailsNonUK => false
-      case AmlsStatuses.ValidAmlsNonUK => false
+      case AmlsStatus.NoAmlsDetailsUK => true
+      case AmlsStatus.ValidAmlsDetailsUK => true
+      case AmlsStatus.ExpiredAmlsDetailsUK => true
+      case AmlsStatus.PendingAmlsDetails => true
+      case AmlsStatus.PendingAmlsDetailsRejected => true
+      case AmlsStatus.NoAmlsDetailsNonUK => false
+      case AmlsStatus.ValidAmlsNonUK => false
     }
 
     def isValid():Boolean = amlsStatus match {
-      case AmlsStatuses.ValidAmlsNonUK => true
-      case AmlsStatuses.ValidAmlsDetailsUK => true
-      case AmlsStatuses.NoAmlsDetailsNonUK => false
-      case AmlsStatuses.NoAmlsDetailsUK => false
-      case AmlsStatuses.ExpiredAmlsDetailsUK => false
-      case AmlsStatuses.PendingAmlsDetails => false
-      case AmlsStatuses.PendingAmlsDetailsRejected => false
+      case AmlsStatus.ValidAmlsNonUK => true
+      case AmlsStatus.ValidAmlsDetailsUK => true
+      case AmlsStatus.NoAmlsDetailsNonUK => false
+      case AmlsStatus.NoAmlsDetailsUK => false
+      case AmlsStatus.ExpiredAmlsDetailsUK => false
+      case AmlsStatus.PendingAmlsDetails => false
+      case AmlsStatus.PendingAmlsDetailsRejected => false
     }
 
     def isExpired():Boolean = amlsStatus match {
-      case AmlsStatuses.ExpiredAmlsDetailsUK => true
-      case AmlsStatuses.ValidAmlsNonUK => false
-      case AmlsStatuses.ValidAmlsDetailsUK => false
-      case AmlsStatuses.NoAmlsDetailsNonUK => false
-      case AmlsStatuses.NoAmlsDetailsUK => false
-      case AmlsStatuses.PendingAmlsDetails => false
-      case AmlsStatuses.PendingAmlsDetailsRejected => false
+      case AmlsStatus.ExpiredAmlsDetailsUK => true
+      case AmlsStatus.ValidAmlsNonUK => false
+      case AmlsStatus.ValidAmlsDetailsUK => false
+      case AmlsStatus.NoAmlsDetailsNonUK => false
+      case AmlsStatus.NoAmlsDetailsUK => false
+      case AmlsStatus.PendingAmlsDetails => false
+      case AmlsStatus.PendingAmlsDetailsRejected => false
     }
 
     def isNoDetails():Boolean = amlsStatus match {
-      case AmlsStatuses.NoAmlsDetailsNonUK => true
-      case AmlsStatuses.NoAmlsDetailsUK => true
-      case AmlsStatuses.ValidAmlsNonUK => false
-      case AmlsStatuses.ValidAmlsDetailsUK => false
-      case AmlsStatuses.ExpiredAmlsDetailsUK => false
-      case AmlsStatuses.PendingAmlsDetails => false
-      case AmlsStatuses.PendingAmlsDetailsRejected => false
+      case AmlsStatus.NoAmlsDetailsNonUK => true
+      case AmlsStatus.NoAmlsDetailsUK => true
+      case AmlsStatus.ValidAmlsNonUK => false
+      case AmlsStatus.ValidAmlsDetailsUK => false
+      case AmlsStatus.ExpiredAmlsDetailsUK => false
+      case AmlsStatus.PendingAmlsDetails => false
+      case AmlsStatus.PendingAmlsDetailsRejected => false
     }
 
     def hasExistingAmls(): Boolean = amlsStatus match {
-      case AmlsStatuses.NoAmlsDetailsNonUK => false
-      case AmlsStatuses.ValidAmlsNonUK => true
-      case AmlsStatuses.NoAmlsDetailsUK => false
-      case AmlsStatuses.ValidAmlsDetailsUK => true
-      case AmlsStatuses.ExpiredAmlsDetailsUK => true
-      case AmlsStatuses.PendingAmlsDetails => true
-      case AmlsStatuses.PendingAmlsDetailsRejected => true
+      case AmlsStatus.NoAmlsDetailsNonUK => false
+      case AmlsStatus.ValidAmlsNonUK => true
+      case AmlsStatus.NoAmlsDetailsUK => false
+      case AmlsStatus.ValidAmlsDetailsUK => true
+      case AmlsStatus.ExpiredAmlsDetailsUK => true
+      case AmlsStatus.PendingAmlsDetails => true
+      case AmlsStatus.PendingAmlsDetailsRejected => true
     }
 
   }

--- a/app/uk/gov/hmrc/agentservicesaccount/models/UpdateAmlsJourney.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/models/UpdateAmlsJourney.scala
@@ -30,13 +30,13 @@ case class UpdateAmlsJourney(status: AmlsStatus,
                             ){
 
   val isUkAgent: Boolean = status match {
-    case AmlsStatuses.NoAmlsDetailsNonUK => false
-    case AmlsStatuses.ValidAmlsNonUK => false
-    case AmlsStatuses.NoAmlsDetailsUK => true
-    case AmlsStatuses.ValidAmlsDetailsUK => true
-    case AmlsStatuses.ExpiredAmlsDetailsUK => true
-    case AmlsStatuses.PendingAmlsDetails => true
-    case AmlsStatuses.PendingAmlsDetailsRejected => true
+    case AmlsStatus.NoAmlsDetailsNonUK => false
+    case AmlsStatus.ValidAmlsNonUK => false
+    case AmlsStatus.NoAmlsDetailsUK => true
+    case AmlsStatus.ValidAmlsDetailsUK => true
+    case AmlsStatus.ExpiredAmlsDetailsUK => true
+    case AmlsStatus.PendingAmlsDetails => true
+    case AmlsStatus.PendingAmlsDetailsRejected => true
   }
 
   val isHmrc:Boolean = isUkAgent && newAmlsBody.contains("HM Revenue and Customs (HMRC)")
@@ -44,13 +44,13 @@ case class UpdateAmlsJourney(status: AmlsStatus,
   // calling .map(_.contains("foo")) would check if the value inside the option _contains_ the provided value but still maintains the optionality
 
   val hasExistingAmls: Boolean = status match {
-    case AmlsStatuses.NoAmlsDetailsNonUK => false
-    case AmlsStatuses.NoAmlsDetailsUK => false
-    case AmlsStatuses.ValidAmlsNonUK => true
-    case AmlsStatuses.ValidAmlsDetailsUK => true
-    case AmlsStatuses.ExpiredAmlsDetailsUK => true
-    case AmlsStatuses.PendingAmlsDetails => true
-    case AmlsStatuses.PendingAmlsDetailsRejected => true
+    case AmlsStatus.NoAmlsDetailsNonUK => false
+    case AmlsStatus.NoAmlsDetailsUK => false
+    case AmlsStatus.ValidAmlsNonUK => true
+    case AmlsStatus.ValidAmlsDetailsUK => true
+    case AmlsStatus.ExpiredAmlsDetailsUK => true
+    case AmlsStatus.PendingAmlsDetails => true
+    case AmlsStatus.PendingAmlsDetailsRejected => true
   }
 }
 

--- a/app/uk/gov/hmrc/agentservicesaccount/views/pages/amls/view_details.scala.html
+++ b/app/uk/gov/hmrc/agentservicesaccount/views/pages/amls/view_details.scala.html
@@ -19,7 +19,6 @@
 @import uk.gov.hmrc.agentservicesaccount.models.AmlsDetails
 @import uk.gov.hmrc.agentservicesaccount.models.AmlsStatus
 @import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.partials._
-@import uk.gov.hmrc.agentservicesaccount.models.AmlsStatuses
 
 @this(
         main: main,
@@ -41,17 +40,17 @@
 @htmlPartial = @{
  mAmlsDetails.fold(
   amlsStatus match {
-   case AmlsStatuses.NoAmlsDetailsUK => no_amls_details_uk()
-   case AmlsStatuses.NoAmlsDetailsNonUK => no_amls_details_non_uk()
+   case AmlsStatus.NoAmlsDetailsUK => no_amls_details_uk()
+   case AmlsStatus.NoAmlsDetailsNonUK => no_amls_details_non_uk()
    case status => throw new RuntimeException(s"unexpected status $status when no amls details present")
   }){ amls =>
   amlsStatus match {
-   case AmlsStatuses.ValidAmlsDetailsUK if amls.isHmrc  => valid_amls_details_uk_hmrc(amls)
-   case AmlsStatuses.ValidAmlsDetailsUK                 => valid_amls_details_uk_non_hmrc(amls)
-   case AmlsStatuses.ValidAmlsNonUK                     => valid_amls_details_non_uk(amls)
-   case AmlsStatuses.PendingAmlsDetails                 => pending_amls_details(amls)
-   case AmlsStatuses.PendingAmlsDetailsRejected         => pending_amls_details_rejected(amls)
-   case AmlsStatuses.ExpiredAmlsDetailsUK               => expired_amls_details_uk(amls)
+   case AmlsStatus.ValidAmlsDetailsUK if amls.isHmrc  => valid_amls_details_uk_hmrc(amls)
+   case AmlsStatus.ValidAmlsDetailsUK                 => valid_amls_details_uk_non_hmrc(amls)
+   case AmlsStatus.ValidAmlsNonUK                     => valid_amls_details_non_uk(amls)
+   case AmlsStatus.PendingAmlsDetails                 => pending_amls_details(amls)
+   case AmlsStatus.PendingAmlsDetailsRejected         => pending_amls_details_rejected(amls)
+   case AmlsStatus.ExpiredAmlsDetailsUK               => expired_amls_details_uk(amls)
    case status => throw new RuntimeException(s"unexpected status $status when amls details present")
   }
  }

--- a/test/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnectorSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnectorSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.agentservicesaccount.connectors
 
 import play.api.test.Helpers._
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsDetailsResponse, AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsDetailsResponse, AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentAssuranceStubs._
 import uk.gov.hmrc.agentservicesaccount.support.BaseISpec
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
@@ -39,10 +39,10 @@ class AgentAssuranceConnectorSpec extends BaseISpec {
     Some(LocalDate.of(2022, 12, 25)),
     Some(LocalDate.of(2023, 12, 25))
   )
-  private val ukAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK,Some(ukAMLSDetails))
+  private val ukAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK,Some(ukAMLSDetails))
 
   private val amlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK,
+    status = AmlsStatus.ValidAmlsDetailsUK,
     newAmlsBody = Some("UK AMLS"),
     newRegistrationNumber = Some("AMLS123"),
     newExpirationDate = Some(LocalDate.parse("2024-10-10"))
@@ -50,7 +50,7 @@ class AgentAssuranceConnectorSpec extends BaseISpec {
 
 
   private val overseasAMLSDetails = AmlsDetails("notHMRC")
-  private val overseasAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK,Some(overseasAMLSDetails))
+  private val overseasAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatus.ValidAmlsNonUK,Some(overseasAMLSDetails))
 
   "getAMLSDetails" should {
     "return UK AMLS details" in {
@@ -93,18 +93,18 @@ class AgentAssuranceConnectorSpec extends BaseISpec {
 
   "getAmlsStatus" should {
     "return UK AMLS Status" in {
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
 
       val result = connector.getAmlsStatus(arn)
 
-      await(result) shouldBe AmlsStatuses.ValidAmlsDetailsUK
+      await(result) shouldBe AmlsStatus.ValidAmlsDetailsUK
     }
     "return Overseas AMLS details" in {
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsNonUK, None), arn)
 
       val result = connector.getAmlsStatus(arn)
 
-      await(result) shouldBe AmlsStatuses.ValidAmlsNonUK
+      await(result) shouldBe AmlsStatus.ValidAmlsNonUK
     }
     "handle 400 Bad Request" in {
       givenAmlsStatusBadRequestForArn(arn)

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.SuspensionDetails
 import uk.gov.hmrc.agents.accessgroups.optin._
 import uk.gov.hmrc.agents.accessgroups.{GroupSummary, UserDetails}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
-import uk.gov.hmrc.agentservicesaccount.models.{AccessGroupSummaries, AgencyDetails, AmlsDetailsResponse, AmlsStatuses, BusinessAddress}
+import uk.gov.hmrc.agentservicesaccount.models.{AccessGroupSummaries, AgencyDetails, AmlsDetailsResponse, AmlsStatus, BusinessAddress}
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentAssuranceStubs._
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentClientAuthorisationStubs._
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentPermissionsStubs._
@@ -445,7 +445,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdFailure(arn)
       givenOptinStatusFailedForArn(arn)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = controller.manageAccount().apply(fakeRequest("GET", "/manage-account"))
 
       status(response) shouldBe OK
@@ -466,7 +466,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = controller.manageAccount().apply(fakeRequest("GET", "/manage-account"))
 
       status(response) shouldBe OK
@@ -487,7 +487,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty)) // no access groups yet
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -528,7 +528,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq(customSummary))) // there is already an access group
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -565,7 +565,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -592,7 +592,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInSingleUser)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -620,7 +620,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutWrongClientCount)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -648,7 +648,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutSingleUser)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -675,7 +675,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutEligible)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -694,7 +694,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -714,7 +714,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsNonUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.NoAmlsDetailsNonUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -734,7 +734,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ValidAmlsNonUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -755,7 +755,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetails, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.PendingAmlsDetails, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -776,7 +776,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.NoAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -796,7 +796,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetailsRejected, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.PendingAmlsDetailsRejected, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -817,7 +817,7 @@ class AgentServicesControllerSpec extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ExpiredAmlsDetailsUK, None), arn)
+      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatus.ExpiredAmlsDetailsUK, None), arn)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/AmlsNewSupervisoryBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/AmlsNewSupervisoryBodyControllerSpec.scala
@@ -29,7 +29,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.support.TestConstants
 import uk.gov.hmrc.agentservicesaccount.utils.AMLSLoader
@@ -59,13 +59,13 @@ class AmlsNewSupervisoryBodyControllerSpec extends PlaySpec
   private val amlsDetailsResponse = Future.successful(amlsDetails)
 
   private val ukAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK,
+    status = AmlsStatus.ValidAmlsDetailsUK,
     isAmlsBodyStillTheSame = Some(true),
     newAmlsBody = Some("ACCA")
   )
 
   private val overseasAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsNonUK,
+    status = AmlsStatus.ValidAmlsNonUK,
     newAmlsBody = Some("OS AMLS"),
     newRegistrationNumber = Some("AMLS123"),
     newExpirationDate = Some(LocalDate.parse("2024-10-10"))

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/CheckYourAnswersControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, SuspensionDetails, Utr}
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AgencyDetails, AgentDetailsDesResponse, AmlsRequest, AmlsStatuses, BusinessAddress, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AgencyDetails, AgentDetailsDesResponse, AmlsRequest, AmlsStatus, BusinessAddress, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.utils.AMLSLoader
 import uk.gov.hmrc.agentservicesaccount.views.components.models.SummaryListData
@@ -83,7 +83,7 @@ class CheckYourAnswersControllerSpec extends PlaySpec with IdiomaticMockito with
       Some(credentialRole)))
 
   private val ukAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK,
+    status = AmlsStatus.ValidAmlsDetailsUK,
     newAmlsBody = Some("ABC"),
     newRegistrationNumber = Some("1234567890"),
     newExpirationDate = Some(LocalDate.now())
@@ -218,7 +218,7 @@ class CheckYourAnswersControllerSpec extends PlaySpec with IdiomaticMockito with
 
     "expected journey data is missing" should {
       val journey = UpdateAmlsJourney(
-        status = AmlsStatuses.ValidAmlsNonUK,
+        status = AmlsStatus.ValidAmlsNonUK,
         newAmlsBody = None,
         newRegistrationNumber = Some(registrationNumber),
         newExpirationDate = None
@@ -234,7 +234,7 @@ class CheckYourAnswersControllerSpec extends PlaySpec with IdiomaticMockito with
 
     "journey data is for an overseas agent" should {
       val journey = UpdateAmlsJourney(
-        status = AmlsStatuses.ValidAmlsNonUK,
+        status = AmlsStatus.ValidAmlsNonUK,
         newAmlsBody = Some(supervisoryBody),
         newRegistrationNumber = Some(registrationNumber),
         newExpirationDate = None
@@ -296,7 +296,7 @@ class CheckYourAnswersControllerSpec extends PlaySpec with IdiomaticMockito with
           mockAppConfig.enableNonHmrcSupervisoryBody returns true
           mockAgentClientAuthorisationConnector.getAgentRecord()(*[HeaderCarrier], *[ExecutionContext]) returns Future.successful(agentRecord)
           mockUpdateAmlsJourneyRepository.getFromSession(*[DataKey[UpdateAmlsJourney]])(*[Reads[UpdateAmlsJourney]], *[Request[_]]) returns
-            Future.successful(Some(UpdateAmlsJourney(AmlsStatuses.ValidAmlsDetailsUK, None, None, None, None)))
+            Future.successful(Some(UpdateAmlsJourney(AmlsStatus.ValidAmlsDetailsUK, None, None, None, None)))
 
           mockAgentClientAuthorisationConnector.getAgentRecord()(*[HeaderCarrier], *[ExecutionContext]) returns Future.successful(agentRecord)
 
@@ -311,7 +311,7 @@ class CheckYourAnswersControllerSpec extends PlaySpec with IdiomaticMockito with
       val renewalDateMessageKey = "amls.check-your-answers.renewal-date"
       val renewalDate = LocalDate.of(2001, 1, 1)
       val journey = UpdateAmlsJourney(
-        status = AmlsStatuses.ValidAmlsDetailsUK,
+        status = AmlsStatus.ValidAmlsDetailsUK,
         newAmlsBody = Some(supervisoryBodyDescription),
         newRegistrationNumber = Some(registrationNumber),
         newExpirationDate = Some(renewalDate)

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ConfirmRegistrationNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ConfirmRegistrationNumberControllerSpec.scala
@@ -29,7 +29,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.support.TestConstants
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.confirm_registration_number
@@ -56,7 +56,7 @@ class ConfirmRegistrationNumberControllerSpec extends PlaySpec
   private val amlsDetailsResponse = Future.successful(amlsDetails)
 
   private val ukAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK
+    status = AmlsStatus.ValidAmlsDetailsUK
   )
 
   trait Setup {

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ConfirmSupervisoryBodyControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ConfirmSupervisoryBodyControllerSpec.scala
@@ -29,7 +29,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.support.TestConstants
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.confirm_supervisory_body
@@ -57,11 +57,11 @@ class ConfirmSupervisoryBodyControllerSpec extends PlaySpec
   private val amlsDetailsResponse = Future.successful(amlsDetails)
 
   private val ukAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK
+    status = AmlsStatus.ValidAmlsDetailsUK
   )
 
   private val overseasAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsNonUK,
+    status = AmlsStatus.ValidAmlsNonUK,
     newAmlsBody = Some("OS AMLS"),
     newRegistrationNumber = Some("AMLS123"),
     newExpirationDate = Some(LocalDate.parse("2024-10-10"))

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/EnterRegistrationNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/EnterRegistrationNumberControllerSpec.scala
@@ -29,7 +29,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.support.TestConstants
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.enter_registration_number
@@ -54,13 +54,13 @@ class EnterRegistrationNumberControllerSpec extends PlaySpec
   private val fakeRequest = FakeRequest()
 
   private val ukAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK,
+    status = AmlsStatus.ValidAmlsDetailsUK,
     newAmlsBody = Some("ACCA"),
     newRegistrationNumber = Some("XAML00000123456")
   )
 
   private val overseasAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsNonUK,
+    status = AmlsStatus.ValidAmlsNonUK,
     newAmlsBody = Some("OS AMLS"),
     newRegistrationNumber = Some("AMLS123"),
     newExpirationDate = Some(LocalDate.parse("2024-10-10")),

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/EnterRenewalDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/EnterRenewalDateControllerSpec.scala
@@ -29,7 +29,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.agentservicesaccount.actions.{Actions, AuthActions}
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.connectors.{AgentAssuranceConnector, AgentClientAuthorisationConnector}
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsStatuses, UpdateAmlsJourney}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsStatus, UpdateAmlsJourney}
 import uk.gov.hmrc.agentservicesaccount.repository.UpdateAmlsJourneyRepository
 import uk.gov.hmrc.agentservicesaccount.support.TestConstants
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.enter_renewal_date
@@ -54,11 +54,11 @@ class EnterRenewalDateControllerSpec extends PlaySpec
   private val fakeRequest = FakeRequest()
 
   private val ukUpdateAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK
+    status = AmlsStatus.ValidAmlsDetailsUK
   )
 
   private val overseasUpdateAmlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsNonUK
+    status = AmlsStatus.ValidAmlsNonUK
   )
 
   private val newExpirationDate = LocalDate.now.plusMonths(11)

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ViewDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/amls/ViewDetailsControllerSpec.scala
@@ -53,9 +53,9 @@ class ViewDetailsControllerSpec extends PlaySpec
   private val fakeRequest = FakeRequest()
 
   private val amlsDetails = AmlsDetails(supervisoryBody = "HMRC")
-  private val amlsDetailsResponsse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK,  Some(amlsDetails))
-  private val amlsNoDetailsResponsse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None)
-  private val amlsUpdateJourney = UpdateAmlsJourney(status = AmlsStatuses.ValidAmlsDetailsUK)
+  private val amlsDetailsResponsse = AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK,  Some(amlsDetails))
+  private val amlsNoDetailsResponsse = AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK, None)
+  private val amlsUpdateJourney = UpdateAmlsJourney(status = AmlsStatus.ValidAmlsDetailsUK)
 
   trait Setup {
     protected val mockAppConfig: AppConfig = mock[AppConfig]
@@ -72,7 +72,7 @@ class ViewDetailsControllerSpec extends PlaySpec
     protected val mockUpdateAmlsJourneyRepository: UpdateAmlsJourneyRepository = mock[UpdateAmlsJourneyRepository]
     protected val mockView: view_details = mock[view_details]
     protected val cc: MessagesControllerComponents = stubMessagesControllerComponents()
-    protected val dataKey = DataKey[UpdateAmlsJourney]("amlsJourney")
+    protected val dataKey: DataKey[UpdateAmlsJourney] = DataKey[UpdateAmlsJourney]("amlsJourney")
 
     object TestController extends ViewDetailsController(mockActions, mockUpdateAmlsJourneyRepository, mockAgentAssuranceConnector, mockView, cc)(mockAppConfig, ec)
   }

--- a/test/uk/gov/hmrc/agentservicesaccount/endpoints/AMLSDetailsEndpoint.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/endpoints/AMLSDetailsEndpoint.scala
@@ -20,7 +20,7 @@ import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.test.Helpers._
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsDetailsResponse, AmlsStatuses}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsDetailsResponse, AmlsStatus}
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentAssuranceStubs.{givenAMLSDetailsForArn, givenAMLSDetailsServerErrorForArn}
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentClientAuthorisationStubs.givenAgentRecordFound
 import uk.gov.hmrc.agentservicesaccount.stubs.CookieHelper
@@ -53,7 +53,7 @@ class AMLSDetailsEndpoint extends BaseISpec with GuiceOneServerPerSuite with Coo
     Some(LocalDate.of(2022, 1, 25)),
     Some(LocalDate.of(2023, 12, 7))
   )
-  private val ukAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK,Some(ukAMLSDetails))
+  private val ukAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatus.ValidAmlsDetailsUK,Some(ukAMLSDetails))
 
   "View AMLS Supervision Details endpoint" should {
     "return successfully when everything works" in {

--- a/test/uk/gov/hmrc/agentservicesaccount/model/AmlsStatusSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/model/AmlsStatusSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentservicesaccount.model
+
+import play.api.libs.json.{JsObject, JsString, Json}
+import uk.gov.hmrc.agentservicesaccount.models.AmlsStatus
+import uk.gov.hmrc.agentservicesaccount.support.UnitSpec
+
+class AmlsStatusSpec extends UnitSpec {
+
+  "AmlsStatus" should {
+    "bind from a QueryString parameter" in {
+      val status = AmlsStatus.queryBindable.bind("status", Map("status" -> Seq("NoAmlsDetailsUK")))
+
+      status shouldBe Some(Right(AmlsStatus.NoAmlsDetailsUK))
+    }
+
+    "serialise to a string in JSON" in {
+      Json.toJson(AmlsStatus.ExpiredAmlsDetailsUK) shouldBe JsString("ExpiredAmlsDetailsUK")
+    }
+
+    "parse a value from JSON" in {
+      val json: JsObject = Json.parse(""" { "status": "PendingAmlsDetailsRejected" } """).as[JsObject]
+      json.value("status").as[AmlsStatus] shouldBe AmlsStatus.PendingAmlsDetailsRejected
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentservicesaccount/views/pages/amls/ViewDetailsViewSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/views/pages/amls/ViewDetailsViewSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.i18n._
 import play.api.test.FakeRequest
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
-import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatuses}
+import uk.gov.hmrc.agentservicesaccount.models.{AmlsDetails, AmlsStatus}
 import uk.gov.hmrc.agentservicesaccount.support.BaseISpec
 import uk.gov.hmrc.agentservicesaccount.views.html.pages.amls.view_details
 
@@ -71,9 +71,9 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-   s"amlsStatus is ${AmlsStatuses.NoAmlsDetailsUK}" should {
+   s"amlsStatus is ${AmlsStatus.NoAmlsDetailsUK}" should {
 
-     val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.NoAmlsDetailsUK, None)(FakeRequest(), messages, appConfig).body)
+     val doc: Document = Jsoup.parse(view.apply(AmlsStatus.NoAmlsDetailsUK, None)(FakeRequest(), messages, appConfig).body)
 
      testServiceStaticContent(doc)
 
@@ -99,9 +99,9 @@ class ViewDetailsViewSpec extends BaseISpec {
      }
    }
 
-    s"amlsStatus is ${AmlsStatuses.NoAmlsDetailsNonUK}" should {
+    s"amlsStatus is ${AmlsStatus.NoAmlsDetailsNonUK}" should {
 
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.NoAmlsDetailsNonUK, None)(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.NoAmlsDetailsNonUK, None)(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -120,10 +120,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.ExpiredAmlsDetailsUK}" should {
+    s"amlsStatus is ${AmlsStatus.ExpiredAmlsDetailsUK}" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "HMRC", membershipNumber = Some("123"), membershipExpiresOn = Some(LocalDate.parse("2024-02-10")))
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.ExpiredAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.ExpiredAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -146,10 +146,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.ValidAmlsDetailsUK} when HMRC registered" should {
+    s"amlsStatus is ${AmlsStatus.ValidAmlsDetailsUK} when HMRC registered" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "HMRC", membershipNumber = Some("123"), membershipExpiresOn = Some(LocalDate.parse("2025-02-10")))
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.ValidAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.ValidAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -176,10 +176,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.ValidAmlsDetailsUK} when not HMRC registered" should {
+    s"amlsStatus is ${AmlsStatus.ValidAmlsDetailsUK} when not HMRC registered" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "ICAEW", membershipNumber = Some("123"), membershipExpiresOn = Some(LocalDate.parse("2025-02-10")))
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.ValidAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.ValidAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -210,10 +210,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.ValidAmlsNonUK}" should {
+    s"amlsStatus is ${AmlsStatus.ValidAmlsNonUK}" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "ICA", membershipNumber = Some("123"), membershipExpiresOn = None)
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.ValidAmlsNonUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.ValidAmlsNonUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -237,10 +237,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.PendingAmlsDetails}" should {
+    s"amlsStatus is ${AmlsStatus.PendingAmlsDetails}" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "HMRC", membershipNumber = Some("123"), appliedOn = Some(LocalDate.parse("2024-10-10")))
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.PendingAmlsDetails, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.PendingAmlsDetails, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -264,10 +264,10 @@ class ViewDetailsViewSpec extends BaseISpec {
       }
     }
 
-    s"amlsStatus is ${AmlsStatuses.PendingAmlsDetailsRejected}" should {
+    s"amlsStatus is ${AmlsStatus.PendingAmlsDetailsRejected}" should {
 
       val amlsDetails = AmlsDetails(supervisoryBody = "HMRC", membershipNumber = Some("123"), appliedOn = Some(LocalDate.parse("2024-10-10")))
-      val doc: Document = Jsoup.parse(view.apply(AmlsStatuses.PendingAmlsDetailsRejected, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+      val doc: Document = Jsoup.parse(view.apply(AmlsStatus.PendingAmlsDetailsRejected, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
 
       testServiceStaticContent(doc)
 
@@ -294,7 +294,7 @@ class ViewDetailsViewSpec extends BaseISpec {
     "amlsStatus expects amlsDetails but none provided" should {
       "throw exception" in {
         an[RuntimeException] mustBe thrownBy{
-          Jsoup.parse(view.apply(AmlsStatuses.PendingAmlsDetailsRejected, None)(FakeRequest(), messages, appConfig).body)
+          Jsoup.parse(view.apply(AmlsStatus.PendingAmlsDetailsRejected, None)(FakeRequest(), messages, appConfig).body)
         }
       }
     }
@@ -302,7 +302,7 @@ class ViewDetailsViewSpec extends BaseISpec {
       "throw exception" in {
         val amlsDetails = AmlsDetails(supervisoryBody = "HMRC", membershipNumber = Some("123"), appliedOn = Some(LocalDate.parse("2024-10-10")))
         an[RuntimeException] mustBe thrownBy{
-          Jsoup.parse(view.apply(AmlsStatuses.NoAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
+          Jsoup.parse(view.apply(AmlsStatus.NoAmlsDetailsUK, Some(amlsDetails))(FakeRequest(), messages, appConfig).body)
         }
       }
     }


### PR DESCRIPTION
The bulk of the changes are related to moving the statuses from `AmlsStatuses` to `AmlsStatus` as was the case prior to the change. This was done because the implicit JSON formatter was unavailable due to the difference in class names.

The main point of the PR is to add missing tests.