### PR TITLE
APB-9618 using URI interpolation to support base urls with empty strings

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/SignOutController.scala
@@ -20,9 +20,9 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.MessagesControllerComponents
+import sttp.model.Uri.UriContext
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.views.html.signed_out
-import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
@@ -37,12 +37,12 @@ extends FrontendController(cc)
 with I18nSupport {
 
   private def signOutWithContinue(continue: String) = {
-    val signOutAndRedirectUrl: String = url"${appConfig.signOut}?${Map("continue" -> continue)}".toString
+    val signOutAndRedirectUrl: String = uri"${appConfig.signOut}?${Map("continue" -> continue)}".toString
     Redirect(signOutAndRedirectUrl)
   }
 
   def signOut: Action[AnyContent] = Action.async {
-    val continue = url"${appConfig.asaFrontendExternalUrl + routes.SurveyController.showSurvey().url}"
+    val continue = uri"${appConfig.asaFrontendExternalUrl + routes.SurveyController.showSurvey().url}"
     Future successful signOutWithContinue(continue.toString)
   }
 
@@ -55,7 +55,7 @@ with I18nSupport {
   }
 
   def timeOut: Action[AnyContent] = Action.async { implicit request =>
-    val continue = url"${appConfig.asaFrontendExternalUrl + routes.SignOutController.timedOut().url}"
+    val continue = uri"${appConfig.asaFrontendExternalUrl + routes.SignOutController.timedOut().url}"
     Future.successful(signOutWithContinue(continue.toString))
   }
 

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/SignOutControllerSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.Helpers
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.support.BaseISpec
-import uk.gov.hmrc.http.StringContextOps
+import sttp.model.Uri.UriContext
 
 class SignOutControllerSpec
 extends BaseISpec {
@@ -34,12 +34,12 @@ extends BaseISpec {
   def signOutUrlWithContinue(continue: String): String = {
     val signOutBaseUrl = "http://localhost:9099"
     val signOutPath = "/bas-gateway/sign-out-without-state"
-    url"""${signOutBaseUrl + signOutPath}?${Map("continue" -> continue)}""".toString
+    uri"""${signOutBaseUrl + signOutPath}?${Map("continue" -> continue)}""".toString
   }
 
   "GET /sign-out" should {
     "remove session and redirect to /home/survey" in {
-      val continueUrl = url"${appConfig.asaFrontendExternalUrl + "/agent-services-account/home/survey"}"
+      val continueUrl = uri"${appConfig.asaFrontendExternalUrl + "/agent-services-account/home/survey"}"
       val response = controller.signOut(fakeRequest("GET", "/")).futureValue
       status(response) shouldBe 303
       redirectLocation(response) shouldBe Some(signOutUrlWithContinue(continueUrl.toString))
@@ -65,7 +65,7 @@ extends BaseISpec {
 
   "GET /time-out" should {
     "redirect to bas-gateway-frontend/sign-out-without-state with timed out page as continue" in {
-      val continue = url"${appConfig.asaFrontendExternalUrl + routes.SignOutController.timedOut().url}"
+      val continue = uri"${appConfig.asaFrontendExternalUrl + routes.SignOutController.timedOut().url}"
       val response = controller.timeOut()(fakeRequest())
       status(response) shouldBe 303
       Helpers.redirectLocation(response) shouldBe Some(signOutUrlWithContinue(continue.toString))


### PR DESCRIPTION
Using URI instead of URL to support relative URI's in the higher environments