### PR TITLE
APB-9692 stop using broken continueFromGGSignIn

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/config/AppConfig.scala
@@ -80,8 +80,6 @@ extends Logging {
   lazy val signOut: String = s"$basGatewayFrontendExternalUrl$signOutPath"
   lazy val signInUrl: String = s"$basGatewayFrontendExternalUrl$signInPath"
 
-  lazy val continueFromGGSignIn = s"$signInUrl?continue=${urlEncode(s"$asaFrontendExternalUrl/agent-services-account")}"
-
   def signOutUrlWithSurvey(surveyKey: String): String = s"$basGatewayFrontendExternalUrl$signOutPath?continue=${urlEncode(signOutContinueUrl + surveyKey)}"
 
   val agentMappingFrontendExternalUrl: String = getConfString("agent-mapping-frontend.external-url")

--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/SignOutController.scala
@@ -47,7 +47,8 @@ with I18nSupport {
   }
 
   def signedOut: Action[AnyContent] = Action.async {
-    Future successful signOutWithContinue(appConfig.continueFromGGSignIn)
+    val continue = uri"${appConfig.asaFrontendExternalUrl + routes.AgentServicesController.showAgentServicesAccount().url}"
+    Future successful signOutWithContinue(continue.toString)
   }
 
   def onlineSignIn: Action[AnyContent] = Action.async {
@@ -60,7 +61,7 @@ with I18nSupport {
   }
 
   def timedOut: Action[AnyContent] = Action.async { implicit request =>
-    Future successful Forbidden(signedOutView(appConfig.continueFromGGSignIn))
+    Future successful Ok(signedOutView(routes.AgentServicesController.showAgentServicesAccount().url))
   }
 
 }

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/SignOutControllerSpec.scala
@@ -48,9 +48,10 @@ extends BaseISpec {
 
   "GET /signed-out" should {
     "redirect to sign in with continue url back to /agent-services-account" in {
+      val continueUrl = uri"${appConfig.asaFrontendExternalUrl + "/agent-services-account/home"}"
       val request = controller.signedOut(FakeRequest("GET", "/"))
       status(request) shouldBe 303
-      Helpers.redirectLocation(request) shouldBe Some(signOutUrlWithContinue(appConfig.continueFromGGSignIn))
+      Helpers.redirectLocation(request) shouldBe Some(signOutUrlWithContinue(continueUrl.toString))
     }
   }
 
@@ -74,8 +75,11 @@ extends BaseISpec {
 
   "GET /timed-out" should {
     "should show the timed out page" in {
-      val request = controller.timedOut(FakeRequest("GET", "/"))
-      status(request) shouldBe 403
+      val response = controller.timedOut(FakeRequest("GET", "/"))
+      status(response) shouldBe 200
+      Helpers
+        .contentAsString(response)
+        .contains("You have been signed out") shouldBe true
     }
   }
 


### PR DESCRIPTION
This config value (a url built as a string with params) has the wrong url and does not redirect to ASA home as it should - rather than fix the uri (to add `/home` onto it) I saw that we didn't need this url built as an appConfig value at all and we could build the url more safely using uri interpolation and also in fact now we land on timed-out from bas-gateway-frontend we can simplify the continue url to be the ASA home url (this is used for "sign back in" link).