### PR TITLE
APB-9212 Removal of unreachable condition in AA connector for AMLS

### DIFF
--- a/app/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnector.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnector.scala
@@ -18,17 +18,16 @@ package uk.gov.hmrc.agentservicesaccount.connectors
 
 import play.api.http.Status.BAD_REQUEST
 import play.api.http.Status.CREATED
-import play.api.http.Status.NO_CONTENT
 import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.agentservicesaccount.config.AppConfig
 import uk.gov.hmrc.agentservicesaccount.models._
+import uk.gov.hmrc.agentservicesaccount.utils.RequestSupport._
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.metrics.Metrics
-import uk.gov.hmrc.agentservicesaccount.utils.RequestSupport._
 
 import java.net.URL
 import javax.inject.Inject
@@ -53,7 +52,6 @@ class AgentAssuranceConnector @Inject() (httpV2: HttpClientV2)(implicit
     response =>
       response.status match {
         case OK => Json.parse(response.body).as[AmlsDetailsResponse]
-        case NO_CONTENT => throw new Exception(s"Error $NO_CONTENT no amls details found") // TODO update when designs are done
         case BAD_REQUEST => throw UpstreamErrorResponse(s"Error $BAD_REQUEST invalid ARN when trying to get amls details", BAD_REQUEST)
         case e => throw UpstreamErrorResponse(s"Error $e unable to get amls details", e)
       }

--- a/app/uk/gov/hmrc/agentservicesaccount/controllers/amls/ViewDetailsController.scala
+++ b/app/uk/gov/hmrc/agentservicesaccount/controllers/amls/ViewDetailsController.scala
@@ -49,11 +49,11 @@ with I18nSupport {
 
   def showPage: Action[AnyContent] = actions.authActionCheckSuspend.async { implicit request =>
     actions.ifFeatureEnabled(appConfig.enableNonHmrcSupervisoryBody) {
-      agentAssuranceConnector.getAMLSDetailsResponse(request.agentInfo.arn.value).flatMap { amlsDetailsResponce =>
-        saveAmlsJourney(UpdateAmlsJourney(status = amlsDetailsResponce.status)).map { _ =>
-          amlsDetailsResponce.details match {
-            case details @ Some(_) => Ok(viewDetails(amlsDetailsResponce.status, details))
-            case None => Ok(viewDetails(amlsDetailsResponce.status, None))
+      agentAssuranceConnector.getAMLSDetailsResponse(request.agentInfo.arn.value).flatMap { amlsDetailsResponse =>
+        saveAmlsJourney(UpdateAmlsJourney(status = amlsDetailsResponse.status)).map { _ =>
+          amlsDetailsResponse.details match {
+            case details @ Some(_) => Ok(viewDetails(amlsDetailsResponse.status, details))
+            case None => Ok(viewDetails(amlsDetailsResponse.status, None))
           }
         }
       }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
   private val mongoVersion: String = "2.6.0"
-  private val bootstrapVersion: String = "9.14.0"
+  private val bootstrapVersion: String = "9.16.0"
   private val enumeratumVersion = "1.9.0"
 
   val compile: Seq[ModuleID] = Seq(
@@ -20,7 +20,7 @@ object AppDependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"    % mongoVersion      % Test,
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"     % bootstrapVersion  % Test,
-    "org.mockito"       %% "mockito-scala-scalatest"    % "2.0.0"         % Test,
+    "org.mockito"       %% "mockito-scala-scalatest"    % "2.0.0"           % Test,
     "org.scalamock"     %% "scalamock"                  % "7.4.0"           % Test
   )
 

--- a/test/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnectorSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/connectors/AgentAssuranceConnectorSpec.scala
@@ -20,7 +20,6 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.agentservicesaccount.models.AmlsDetails
 import uk.gov.hmrc.agentservicesaccount.models.AmlsDetailsResponse
 import uk.gov.hmrc.agentservicesaccount.models.AmlsStatuses
-import uk.gov.hmrc.agentservicesaccount.models.UpdateAmlsJourney
 import uk.gov.hmrc.agentservicesaccount.stubs.AgentAssuranceStubs._
 import uk.gov.hmrc.agentservicesaccount.support.BaseISpec
 import uk.gov.hmrc.http.UpstreamErrorResponse
@@ -43,13 +42,6 @@ extends BaseISpec {
   )
   private val ukAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, Some(ukAMLSDetails))
 
-  private val amlsJourney = UpdateAmlsJourney(
-    status = AmlsStatuses.ValidAmlsDetailsUK,
-    newAmlsBody = Some("UK AMLS"),
-    newRegistrationNumber = Some("AMLS123"),
-    newExpirationDate = Some(LocalDate.parse("2024-10-10"))
-  )
-
   private val overseasAMLSDetails = AmlsDetails("notHMRC")
   private val overseasAMLSDetailsResponse = AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, Some(overseasAMLSDetails))
 
@@ -67,13 +59,6 @@ extends BaseISpec {
       val result = connector.getAMLSDetails(arn.value)
 
       await(result) shouldBe overseasAMLSDetails
-    }
-    "handle 204 No Content" in {
-      givenAMLSDetailsNotFoundForArn(arn.value)
-
-      intercept[Exception] {
-        await(connector.getAMLSDetails(arn.value))
-      }.getMessage shouldBe s"Error $NO_CONTENT no amls details found"
     }
     "handle 400 Bad Request" in {
       givenAMLSDetailsBadRequestForArn(arn.value)
@@ -93,28 +78,28 @@ extends BaseISpec {
 
   "getAmlsStatus" should {
     "return UK AMLS Status" in {
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
 
       val result = connector.getAmlsStatus(arn)
 
       await(result) shouldBe AmlsStatuses.ValidAmlsDetailsUK
     }
     "return Overseas AMLS details" in {
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn.value)
 
       val result = connector.getAmlsStatus(arn)
 
       await(result) shouldBe AmlsStatuses.ValidAmlsNonUK
     }
     "handle 400 Bad Request" in {
-      givenAmlsStatusBadRequestForArn(arn)
+      givenAMLSDetailsBadRequestForArn(arn.value)
 
       intercept[UpstreamErrorResponse] {
         await(connector.getAmlsStatus(arn))
       }.getMessage shouldBe "Error 400 invalid ARN when trying to get amls details"
     }
     "handle 500 Internal Server Error" in {
-      givenAmlsStatusServerErrorForArn(arn)
+      givenAMLSDetailsServerErrorForArn(arn.value)
 
       intercept[UpstreamErrorResponse] {
         await(connector.getAmlsStatus(arn))

--- a/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/controllers/AgentServicesControllerSpec.scala
@@ -451,7 +451,7 @@ extends BaseISpec {
 
       givenAuthorisedAsAgentWith(arn.value)
       givenAgentRecordFound(agentRecord)
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsUK, None), arn.value)
       val response = controllerWithGranPermsDisabled.manageAccount().apply(fakeRequest("GET", "/manage-account"))
 
       status(response) shouldBe OK
@@ -473,7 +473,7 @@ extends BaseISpec {
       givenSyncEacdFailure(arn)
       givenOptinStatusFailedForArn(arn)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = controller.manageAccount().apply(fakeRequest("GET", "/manage-account"))
 
       status(response) shouldBe OK
@@ -494,7 +494,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = controller.manageAccount().apply(fakeRequest("GET", "/manage-account"))
 
       status(response) shouldBe OK
@@ -515,7 +515,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty)) // no access groups yet
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -556,7 +556,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq(customSummary))) // there is already an access group
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -593,7 +593,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -622,7 +622,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInSingleUser)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -652,7 +652,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutWrongClientCount)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -680,7 +680,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutSingleUser)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -709,7 +709,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedOutEligible)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -728,7 +728,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -748,7 +748,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsNonUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsNonUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -768,7 +768,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ValidAmlsNonUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -788,7 +788,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetails, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetails, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -808,7 +808,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.NoAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -828,7 +828,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetailsRejected, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.PendingAmlsDetailsRejected, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200
@@ -848,7 +848,7 @@ extends BaseISpec {
       givenSyncEacdSuccess(arn)
       givenOptinStatusSuccessReturnsForArn(arn, OptedInNotReady)
       givenAccessGroupsForArn(arn, AccessGroupSummaries(Seq.empty))
-      givenAmlsStatusForArn(AmlsDetailsResponse(AmlsStatuses.ExpiredAmlsDetailsUK, None), arn)
+      givenAMLSDetailsForArn(AmlsDetailsResponse(AmlsStatuses.ExpiredAmlsDetailsUK, None), arn.value)
       val response = await(controller.manageAccount()(fakeRequest("GET", "/manage-account")))
 
       status(response) shouldBe 200

--- a/test/uk/gov/hmrc/agentservicesaccount/stubs/AgentAssuranceStubs.scala
+++ b/test/uk/gov/hmrc/agentservicesaccount/stubs/AgentAssuranceStubs.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.agentservicesaccount.stubs
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.libs.json.Json
-import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.agentservicesaccount.models.AgentDetailsDesResponse
 import uk.gov.hmrc.agentservicesaccount.models.AmlsDetailsResponse
 
@@ -35,12 +34,6 @@ object AgentAssuranceStubs {
         .withBody(Json.toJson(amlsDetailsResponse).toString())
     ))
 
-  def givenAMLSDetailsNotFoundForArn(arn: String): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/$arn"))
-    .willReturn(
-      aResponse()
-        .withStatus(204)
-    ))
-
   def givenAMLSDetailsBadRequestForArn(arn: String): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/$arn"))
     .willReturn(
       aResponse()
@@ -48,28 +41,6 @@ object AgentAssuranceStubs {
     ))
 
   def givenAMLSDetailsServerErrorForArn(arn: String): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/$arn"))
-    .willReturn(
-      aResponse()
-        .withStatus(500)
-    ))
-
-  def givenAmlsStatusForArn(
-    amlsDetailsResponse: AmlsDetailsResponse,
-    arn: Arn
-  ): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/${arn.value}"))
-    .willReturn(
-      aResponse()
-        .withStatus(200)
-        .withBody(Json.toJson(amlsDetailsResponse).toString())
-    ))
-
-  def givenAmlsStatusBadRequestForArn(arn: Arn): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/${arn.value}"))
-    .willReturn(
-      aResponse()
-        .withStatus(400)
-    ))
-
-  def givenAmlsStatusServerErrorForArn(arn: Arn): StubMapping = stubFor(get(urlEqualTo(s"/agent-assurance/amls/arn/${arn.value}"))
     .willReturn(
       aResponse()
         .withStatus(500)


### PR DESCRIPTION
After looking at the AA code for the relevant endpoint I can see 204 is not a possible response code. The code only returns: 200 for positive cases, with possible 400 if ARN is invalid (though not sure how realistic this is). Kibana data also supports this - the endpoint has only returned 200 in the last 2 weeks (~18,000 requests).

Some wiremock stub funcs were removed because they were duplicates of other funcs stubbing the same AMLS endpoint.